### PR TITLE
feat: Modal 컴포넌트 확장을 위한 props 추가

### DIFF
--- a/src/components/common/Modal.tsx
+++ b/src/components/common/Modal.tsx
@@ -1,3 +1,4 @@
+import { cn } from '@/lib'
 import { XIcon } from 'lucide-react'
 import type { ReactNode, MouseEvent } from 'react'
 
@@ -6,6 +7,9 @@ interface ModalProps {
   onClose: () => void
   children: ReactNode
   className?: string
+  wrapperClassName?: string
+  innerClassName?: string
+  titleClassName?: string
   title: ReactNode
 }
 
@@ -14,6 +18,9 @@ export function Modal({
   onClose,
   children,
   className,
+  wrapperClassName,
+  innerClassName,
+  titleClassName,
   title,
 }: ModalProps) {
   if (!isOpen) return null
@@ -30,12 +37,17 @@ export function Modal({
       onClick={handleBackdropClick}
     >
       <div
-        className="modal modal-wrapper relative m-10 flex h-4/5 w-full flex-col"
+        className={cn(
+          'modal modal-wrapper relative m-10 flex h-4/5 w-full flex-col',
+          wrapperClassName
+        )}
         role="dialog"
         aria-modal="true"
       >
         <div className="flex items-start justify-between">
-          <h2 className="mt-2 text-xl font-bold">{title}</h2>
+          <h2 className={cn('mt-2 text-xl font-bold', titleClassName)}>
+            {title}
+          </h2>
           <button
             onClick={onClose}
             className="text-3xl font-light"
@@ -44,7 +56,12 @@ export function Modal({
             <XIcon />
           </button>
         </div>
-        <div className="centralize mb-8 h-full flex-col gap-6 overflow-y-auto p-4">
+        <div
+          className={cn(
+            'centralize mb-8 h-full flex-col gap-6 overflow-y-auto p-4',
+            innerClassName
+          )}
+        >
           {children}
         </div>
       </div>


### PR DESCRIPTION
## ✨ PR 개요

Modal 컴포넌트 확장을 위한 props(contentClassName, innerClassName, titleClassName) 추가
- 모달 크기 / 레이아웃 / 타이틀 스타일을 커스터마이징할 수 있도록 확장

## 📌 관련 이슈

Closes #42

## 🧩 작업 내용 (주요 변경사항)

기존 Modal은 내부 컨텐츠 영역의 크기가 고정되어 있어  
DatePicker처럼 작은 모달의 사이즈 조절하기 어려운 점이 있었습니다.

```ts
interface ModalProps {
  isOpen: boolean
  onClose: () => void
  children: ReactNode
  className?: string
  wrapperClassName?: string // 전체 wrapper
  innerClassName?: string // 내부 컨테이너
  titleClassName?: string // 제목 영역
  title: ReactNode
}
```

그래서 기존 Modal 구조는 변경하지 않고, 아래 스타일들을 오버라이드할 수 있도록 확장했습니다.
- `contentClassName`: 모달 박스의 전체 스타일
- `innerClassName`: 내부 컨텐츠 영역 레이아웃
- `titleClassName`: 타이틀 스타일


→ 모두 `optional`이라 기존 모달 사용처에는 아무 영향을 주지 않습니다.
(필요할 때만 사용하는 확장성 기반 변경입니다.)

## 💬 리뷰 포인트

## 📸 스크린샷 (선택)

## 🧠 기타 참고사항

## ✅ PR 체크리스트

- [ ] 커밋 컨벤션 준수 (예: `feat: 로그인 구현`)
- [ ] 불필요한 console.log 제거
- [ ] 로컬에서 실행 확인 완료
