### PR TITLE
feat: 작성/미리보기 전환 및 리스트 렌더링/반응형 개선 (#40)

### DIFF
--- a/src/components/common/MarkdownEditor.tsx
+++ b/src/components/common/MarkdownEditor.tsx
@@ -9,9 +9,12 @@ import {
 import { Button } from './Button'
 import { useState } from 'react'
 import { editorTabVariants } from '@/constants'
+import { markdownToHtml } from '@/lib/markdown'
 
 export function MarkdownEditor() {
   const [mode, setMode] = useState<'write' | 'preview'>('write')
+  const [value, setValue] = useState('')
+
   return (
     <div className="border-custom-gray-200 rounded-lg border">
       <header className="bg-custom-gray-50 border-custom-gray-200 flex h-12 items-center justify-between border-b px-4">
@@ -54,13 +57,16 @@ export function MarkdownEditor() {
       </header>
       {mode === 'write' ? (
         <textarea
+          value={value}
+          onChange={(e) => setValue(e.target.value)}
           placeholder="스터디 그룹에 대한 설명을 작성하세요. 마크다운 문법을 사용할 수 있습니다."
           className="remove-focus-outline min-h-[200px] w-full resize-none border-0 p-4"
         ></textarea>
       ) : (
-        <div className="text-custom-gray-900 remove-focus-outline min-h-[200px] w-full border-0 p-4">
-          미리보기
-        </div>
+        <div
+          className="text-custom-gray-900 remove-focus-outline min-h-[200px] w-full border-0 p-4"
+          dangerouslySetInnerHTML={{ __html: markdownToHtml(value) }}
+        />
       )}
       <div className="text-custom-gray-600 border-custom-gray-200 bg-custom-gray-50 flex h-8 items-center gap-2 border-t px-4 text-sm font-medium">
         <p className="font-normal">마크다운 문법을 사용할 수 있습니다.</p>

--- a/src/components/common/MarkdownEditor.tsx
+++ b/src/components/common/MarkdownEditor.tsx
@@ -17,7 +17,7 @@ export function MarkdownEditor() {
 
   return (
     <div className="border-custom-gray-200 rounded-lg border">
-      <header className="bg-custom-gray-50 border-custom-gray-200 flex h-12 items-center justify-between border-b px-4">
+      <header className="bg-custom-gray-50 border-custom-gray-200 flex h-22 flex-col justify-evenly border-b px-4 sm:h-12 sm:flex-row sm:items-center sm:justify-between">
         <div className="flex gap-4 font-medium">
           <div
             className={editorTabVariants({ active: mode === 'write' })}
@@ -64,17 +64,26 @@ export function MarkdownEditor() {
         ></textarea>
       ) : (
         <div
-          className="text-custom-gray-900 remove-focus-outline min-h-[200px] w-full border-0 p-4"
+          className="text-custom-gray-900 remove-focus-outline markdown-content min-h-[200px] w-full list-inside border-0 p-4"
           dangerouslySetInnerHTML={{ __html: markdownToHtml(value) }}
+          style={{ listStyle: 'decimal' }}
         />
       )}
-      <div className="text-custom-gray-600 border-custom-gray-200 bg-custom-gray-50 flex h-8 items-center gap-2 border-t px-4 text-sm font-medium">
+      <div className="text-custom-gray-600 border-custom-gray-200 bg-custom-gray-50 flex h-18 flex-col justify-center gap-2 border-t px-4 text-xs font-medium sm:h-12 md:h-8 md:flex-row md:items-center md:justify-start">
         <p className="font-normal">마크다운 문법을 사용할 수 있습니다.</p>
-        <span>**굵게**</span>
-        <span>*기울임*</span>
-        <span>`코드`</span>
-        <span>[링크](URL)</span>
-        <span>## 제목</span>
+        <div className="flex flex-col gap-0.5 sm:flex-row md:gap-2">
+          <div className="flex gap-2">
+            <span>**굵게**</span>
+            <span>*기울임*</span>
+            <span>`코드`</span>
+            <span>[링크](URL)</span>
+          </div>
+          <div className="flex gap-2">
+            <span>## 제목</span>
+            <span>- 목록</span>
+            <span>![설명](이미지URL)</span>
+          </div>
+        </div>
       </div>
     </div>
   )

--- a/src/index.css
+++ b/src/index.css
@@ -47,6 +47,18 @@
   body {
     font-family: var(--font-pretendard);
   }
+
+  h1 {
+    @apply text-4xl font-bold;
+  }
+
+  h2 {
+    @apply text-3xl font-semibold;
+  }
+
+  h3 {
+    @apply text-2xl font-medium;
+  }
 }
 
 @layer components {
@@ -69,5 +81,13 @@
 
   .remove-focus-outline {
     @apply focus:ring-0 focus:outline-none;
+  }
+
+  .markdown-content ol {
+    @apply ml-4 list-decimal;
+  }
+
+  .markdown-content ul {
+    @apply ml-4 list-disc;
   }
 }

--- a/src/lib/markdown.ts
+++ b/src/lib/markdown.ts
@@ -1,5 +1,5 @@
-export function markdownToHtml(markdown: string) {
-  let html = markdown
+export function markdownToHtml(markdown: string): string {
+  let html: string = markdown
 
   html = html.replace(/\*\*(.+?)\*\*/g, '<strong>$1</strong>')
 
@@ -7,17 +7,51 @@ export function markdownToHtml(markdown: string) {
 
   html = html.replace(/`(.+?)`/g, '<code>$1</code>')
 
+  html = html.replace(
+    /!\[(.*?)\]\(([^)]*?)\)/g,
+    (_match: string, alt: string, url: string): string => {
+      return `<img src="${url}" alt="${alt || ''}" />`
+    }
+  )
+
   html = html.replace(/\[(.+?)\]\((.+?)\)/g, '<a href="$2">$1</a>')
 
   html = html.replace(/^# (.+)$/gm, '<h1>$1</h1>')
   html = html.replace(/^## (.+)$/gm, '<h2>$1</h2>')
   html = html.replace(/^### (.+)$/gm, '<h3>$1</h3>')
 
-  html = html.replace(/^- (.+)$/gm, '<li>$1</li>')
-  html = html.replace(/<li>(.+)<\/li>/gm, '<ol><li>$1</li></ol>')
+  html = html.replace(
+    /(^|\r?\n)((?:\s*- .+(?:\r?\n|$))+)/g,
+    (_m, prefix, block) => {
+      const items = block
+        .trim()
+        .split(/\r?\n/)
+        .map((line: string) => line.replace(/^\s*- /, '').trim())
+        .filter(Boolean)
+        .map((item: string) => `<li>${item}</li>`)
+        .join('')
+      return `${prefix}<ul>${items}</ul>`
+    }
+  )
 
-  html = html.replace(/^- (.+)$/gm, '<li>$1</li>')
-  html = html.replace(/<li>(.+)<\/li>/gm, '<ul><li>$1</li></ul>')
+  html = html.replace(
+    /(^|\r?\n)((?:\d+\. .+(?:\r?\n|$))+)/g,
+    (_m, prefix, block) => {
+      const items = block
+        .trim()
+        .split(/\r?\n/)
+        .map((line: string) => line.replace(/^\d+\. /, '').trim())
+        .filter(Boolean)
+        .map((item: string) => `<li>${item}</li>`)
+        .join('')
+      return `${prefix}<ol>${items}</ol>`
+    }
+  )
+
+  html = html.replace(
+    /(?<!<\/ul>|<\/ol>|<\/li>|<\/h1>|<\/h2>|<\/h3>)\n/g,
+    '<br/>'
+  )
 
   return html
 }


### PR DESCRIPTION
## ✨ PR 개요

<!-- 어떤 작업을 했는지 간략히 요약 -->
작성/미리보기 전환 및 리스트 렌더링/반응형 개선

## 📌 관련 이슈

<!-- Closes #이슈번호 -->

Closes #40 

## 🧩 작업 내용 (주요 변경사항)

- 마크다운 에디터에 작성/미리보기 전환 기능 추가
- 사진 링크도 첨부할 수 있게 함수에 로직 추가
- html 리스트 요소가 제대로 렌더링 되지 않던 문제 해결 (테일윈드 기본 설정인 list-style: none이 문제였음)
- 반응형 개선

## 💬 리뷰 포인트

<!-- 특히 봐줬으면 하는 부분 (예: 상태관리 로직 구조 괜찮은지 봐주세요) -->

## 📸 스크린샷 (선택)

<!-- UI 변경이 있다면 캡처나 GIF 첨부 -->

https://github.com/user-attachments/assets/35b2d710-125f-499f-9077-8676fd935d86

## 🧠 기타 참고사항

<!-- 추가로 알아야 할 점 (예: 임시로 넣은 더미 데이터 있음) -->

## ✅ PR 체크리스트

- [x] 커밋 컨벤션 준수 (예: `feat: 로그인 구현`)
- [x] 로컬에서 실행 확인 완료
