### PR TITLE
feat: 스터디 그룹 페이지 UI + MSW 연결 (#68)

### DIFF
--- a/src/components/layout/header/Header.tsx
+++ b/src/components/layout/header/Header.tsx
@@ -18,8 +18,8 @@ export function Header({ isSideBarOpen, setIsSideBarOpen }: HeaderProps) {
   }
 
   return (
-    <div className="border-custom-gray-200 flex w-full justify-center border-b border-solid bg-white">
-      <div className="container-1280 fixed z-100 flex h-16 w-full items-center justify-between px-8">
+    <div className="border-custom-gray-200 z-100 flex w-full justify-center border-b border-solid bg-white">
+      <div className="container-1280 fixed flex h-16 w-full items-center justify-between bg-white px-8">
         {isSideBarOpen && <MobileModal setIsModalOpen={setIsSideBarOpen} />}
         <div className="flex items-center gap-[15px] md:hidden">
           <Menu className="h-8 w-8 cursor-pointer" onClick={handleSideBar} />

--- a/src/components/studygroup/StudyCard.tsx
+++ b/src/components/studygroup/StudyCard.tsx
@@ -1,0 +1,63 @@
+import {
+  StudyCardContent,
+  StudyCardFooter,
+  StudyCardThumbnail,
+} from '@/components/studygroup'
+
+export interface StudyCardProps {
+  image: string
+  statusBadge: string
+  statusColor?: string
+  roleBadge?: string
+  memberCount: string
+  name: string
+  dateRange: string
+  lectures: { title: string; instructor: string }[]
+
+  variant?: 'default' | 'completed'
+
+  rating?: number
+  reviewStatus?: 'none' | 'done'
+  onActionClick?: () => void
+}
+
+export function StudyCard({
+  image,
+  statusBadge,
+  statusColor = 'bg-success-500',
+  roleBadge,
+  memberCount,
+  name,
+  dateRange,
+  lectures,
+  variant = 'default',
+  rating = 0,
+  reviewStatus = 'none',
+  onActionClick,
+}: StudyCardProps) {
+  return (
+    <div className="border-custom-gray-200 flex h-[600px] flex-col overflow-hidden rounded-xl border bg-white shadow-sm transition-all hover:shadow-md">
+      <StudyCardThumbnail
+        image={image}
+        name={name}
+        statusBadge={statusBadge}
+        statusColor={statusColor}
+        roleBadge={roleBadge}
+        memberCount={memberCount}
+      />
+      <div className="flex flex-1 flex-col p-5">
+        <StudyCardContent
+          name={name}
+          dateRange={dateRange}
+          lectures={lectures}
+        />
+        <StudyCardFooter
+          variant={variant}
+          rating={rating}
+          reviewStatus={reviewStatus}
+          onActionClick={onActionClick}
+        />
+      </div>
+    </div>
+  )
+}

--- a/src/components/studygroup/StudyCardContent.tsx
+++ b/src/components/studygroup/StudyCardContent.tsx
@@ -1,0 +1,35 @@
+import type { StudyCardProps } from '@/components/studygroup'
+import { Book, Calendar } from 'lucide-react'
+
+export function StudyCardContent({
+  name,
+  dateRange,
+  lectures,
+}: Pick<StudyCardProps, 'name' | 'dateRange' | 'lectures'>) {
+  return (
+    <div className="flex-1">
+      <h3 className="text-custom-gray-900 mb-3 line-clamp-1 text-lg font-bold">
+        {name}
+      </h3>
+      <div className="text-custom-gray-700 space-y-2 text-sm">
+        <div className="flex items-center gap-2">
+          <Calendar size={14} />
+          <span>스터디 기간</span>
+        </div>
+        <p className="pl-5.5 font-medium">{dateRange}</p>
+        <div className="mt-3 flex items-center gap-2">
+          <Book size={14} />
+          <span>스터디 강의 ({lectures.length})</span>
+        </div>
+        <div className="space-y-0.5 pl-5.5">
+          {lectures.map((lecture, idx) => (
+            <div key={idx}>
+              <p className="line-clamp-1 font-medium">{lecture.title}</p>
+              <p className="line-clamp-1">{lecture.instructor}</p>
+            </div>
+          ))}
+        </div>
+      </div>
+    </div>
+  )
+}

--- a/src/components/studygroup/StudyCardFooter.tsx
+++ b/src/components/studygroup/StudyCardFooter.tsx
@@ -1,0 +1,64 @@
+import { ArrowRight, Star } from 'lucide-react'
+import type { StudyCardProps } from './StudyCard'
+import { Button } from '@/components/common'
+import { cn } from '@/lib'
+
+export function StudyCardFooter({
+  variant,
+  rating,
+  reviewStatus,
+  onActionClick,
+}: Pick<
+  StudyCardProps,
+  'variant' | 'rating' | 'reviewStatus' | 'onActionClick'
+>) {
+  if (variant === 'default') {
+    return (
+      <div className="border-custom-gray-100 mt-auto flex justify-end border-t pt-3">
+        <button className="text-primary-600 hover:text-primary-700 flex items-center gap-1.5 text-xs font-medium transition-colors">
+          자세히 보기 <ArrowRight size={14} className="mb-0.5" />
+        </button>
+      </div>
+    )
+  }
+
+  return (
+    <div className="mt-auto space-y-3 pt-5">
+      <div className="border-custom-gray-100 flex items-center justify-between border-t pt-3">
+        <div className="flex items-center gap-1">
+          <span className="text-custom-gray-700 text-xs font-bold">
+            스터디 리뷰
+          </span>
+          <div className="flex">
+            {[1, 2, 3, 4, 5].map((star) => (
+              <Star
+                key={star}
+                className={cn(
+                  'h-3 w-3',
+                  star <= (rating || 0)
+                    ? 'fill-primary-400 text-primary-400'
+                    : 'text-custom-gray-200 fill-gray-200'
+                )}
+              />
+            ))}
+          </div>
+          <span className="text-custom-gray-400 text-xs">({rating})</span>
+        </div>
+        <button className="text-custom-gray-400 hover:text-custom-gray-600 text-xs underline">
+          상세보기
+        </button>
+      </div>
+
+      <Button
+        variant={reviewStatus === 'done' ? 'secondary' : 'primary'}
+        className={cn(
+          'w-full font-bold',
+          reviewStatus === 'done' && 'text-custom-gray-500 bg-custom-gray-100'
+        )}
+        onClick={onActionClick}
+      >
+        {reviewStatus === 'done' ? '리뷰 수정하기' : '리뷰 작성하기'}
+      </Button>
+    </div>
+  )
+}

--- a/src/components/studygroup/StudyCardThumbnail.tsx
+++ b/src/components/studygroup/StudyCardThumbnail.tsx
@@ -1,0 +1,40 @@
+import { cn } from '@/lib'
+import type { StudyCardProps } from './StudyCard'
+
+export function StudyCardThumbnail({
+  image,
+  name,
+  statusBadge,
+  statusColor,
+  roleBadge,
+  memberCount,
+}: Pick<
+  StudyCardProps,
+  'image' | 'name' | 'statusBadge' | 'statusColor' | 'roleBadge' | 'memberCount'
+>) {
+  return (
+    <div className="bg-custom-gray-100 relative w-full overflow-hidden">
+      <img
+        src={image}
+        alt={name}
+        className="aspect-video h-56 w-full object-cover transition-transform duration-300"
+      />
+      <span
+        className={cn(
+          'absolute top-3 left-3 rounded-full px-2 py-1 text-xs font-bold text-white',
+          statusColor
+        )}
+      >
+        {statusBadge}
+      </span>
+      {roleBadge && (
+        <span className="bg-primary-400 absolute top-3 right-3 rounded-full px-2 py-1 text-xs font-bold text-white">
+          {roleBadge}
+        </span>
+      )}
+      <div className="text-custom-gray-900 absolute bottom-3 left-3 flex items-center gap-1 rounded-full bg-white/60 px-3 py-1 backdrop-blur-sm">
+        <span>{memberCount}</span>
+      </div>
+    </div>
+  )
+}

--- a/src/components/studygroup/StudySection.tsx
+++ b/src/components/studygroup/StudySection.tsx
@@ -1,0 +1,39 @@
+import { cn } from '@/lib'
+
+interface StudySectionProps {
+  name: string
+  description: string
+  badgeText: string
+  badgeColor?: string
+  children: React.ReactNode
+  className?: string
+}
+
+export function StudySection({
+  name,
+  description,
+  badgeText,
+  badgeColor = 'bg-primary-100 text-primary-700',
+  children,
+  className,
+}: StudySectionProps) {
+  return (
+    <section className={cn('flex flex-col gap-6', className)}>
+      <div className="flex items-start justify-between">
+        <div className="space-y-1">
+          <h2 className="text-custom-gray-900 text-xl font-bold">{name}</h2>
+          <p className="text-custom-gray-500 text-sm">{description}</p>
+        </div>
+        <span
+          className={cn('rounded-full px-3 py-1 text-xs font-bold', badgeColor)}
+        >
+          {badgeText}
+        </span>
+      </div>
+
+      <div className="grid grid-cols-1 gap-6 md:grid-cols-2 lg:grid-cols-3">
+        {children}
+      </div>
+    </section>
+  )
+}

--- a/src/components/studygroup/index.ts
+++ b/src/components/studygroup/index.ts
@@ -1,0 +1,5 @@
+export * from './StudyCard'
+export * from './StudyCardContent'
+export * from './StudyCardFooter'
+export * from './StudyCardThumbnail'
+export * from './StudySection'

--- a/src/mocks/handler.ts
+++ b/src/mocks/handler.ts
@@ -2,9 +2,15 @@ import { MSW_BASE_URL } from '@/constants/url-constants'
 import { chatHandlers } from '@/mocks/handlers/chat-handlers'
 import { userInformationHandler } from '@/mocks/handlers/user'
 import { http, HttpResponse } from 'msw'
+import { studygroupHandlers } from './handlers/studygroup-handler'
 
 const getTestMSW = http.get(`${MSW_BASE_URL}/get-test`, () => {
   return HttpResponse.text('msw is working!')
 })
 
-export const handlers = [getTestMSW, ...userInformationHandler, ...chatHandlers]
+export const handlers = [
+  getTestMSW,
+  ...userInformationHandler,
+  ...chatHandlers,
+  ...studygroupHandlers,
+]

--- a/src/mocks/handlers/studygroup-handler.ts
+++ b/src/mocks/handlers/studygroup-handler.ts
@@ -1,0 +1,8 @@
+import { http, HttpResponse } from 'msw'
+import { mockStudyList } from './studygroup/mockData'
+
+export const studygroupHandlers = [
+  http.get('/api/v1/study-groups', () => {
+    return HttpResponse.json(mockStudyList)
+  }),
+]

--- a/src/mocks/handlers/studygroup/index.ts
+++ b/src/mocks/handlers/studygroup/index.ts
@@ -1,0 +1,1 @@
+export * from './mockData'

--- a/src/mocks/handlers/studygroup/mockData.ts
+++ b/src/mocks/handlers/studygroup/mockData.ts
@@ -1,0 +1,67 @@
+import type { StudyGroupResponseType } from '@/types'
+
+export const mockStudyList: StudyGroupResponseType[] = [
+  {
+    id: 1,
+    name: 'React 실무 프로젝트 스터디',
+    is_leader: true,
+    start_at: '2024-02-01',
+    end_at: '2024-04-30',
+    max_headcount: 10,
+    current_headcount: 8,
+    profile_img_url:
+      'https://images.unsplash.com/photo-1522202176988-66273c2fd55f',
+    status: 'ONGOING',
+    lectures: [
+      { id: 101, title: 'React 완벽 마스터 강의', instructor: '김카엘' },
+      { id: 102, title: 'Next.js 실전 가이드', instructor: '박프론트' },
+    ],
+    reviews: [],
+  },
+  {
+    id: 2,
+    name: 'Spring Boot 기초반',
+    is_leader: false,
+    start_at: '2023-11-01',
+    end_at: '2024-01-31',
+    max_headcount: 6,
+    current_headcount: 4,
+    profile_img_url:
+      'https://images.unsplash.com/photo-1517245386807-bb43f82c33c4',
+    status: 'PENDING',
+    lectures: [{ id: 201, title: 'Spring Boot 입문', instructor: '최자바' }],
+    reviews: [],
+  },
+  {
+    id: 3,
+    name: 'Vue.js 마스터 스터디',
+    is_leader: false,
+    start_at: '2023-08-01',
+    end_at: '2023-11-30',
+    max_headcount: 8,
+    current_headcount: 6,
+    profile_img_url:
+      'https://images.unsplash.com/photo-1516321318423-f06f85e504b3',
+    status: 'ENDED',
+    lectures: [{ id: 301, title: 'Vue.js 완벽 마스터', instructor: '이뷰' }],
+    reviews: [],
+  },
+  {
+    id: 4,
+    name: 'TypeScript 심화 스터디',
+    is_leader: false,
+    start_at: '2023-09-01',
+    end_at: '2023-12-15',
+    max_headcount: 6,
+    current_headcount: 5,
+    profile_img_url:
+      'https://images.unsplash.com/photo-1699885960867-56d5f5262d38',
+    status: 'ENDED',
+    lectures: [
+      { id: 401, title: 'TypeScript 마스터', instructor: '한스크립트' },
+    ],
+    reviews: [
+      { id: 99, is_mine: true, star_rating: 4, content: '좋았습니다.' },
+    ],
+  },
+]

--- a/src/pages/StudyDetailPage.tsx
+++ b/src/pages/StudyDetailPage.tsx
@@ -7,7 +7,7 @@ import {
   StudyScheduleCalendar,
 } from '@/components/studygroup-detail'
 
-export default function StudyDetailPage() {
+export function StudyDetailPage() {
   return (
     <div className="flex flex-col gap-8 px-8 pb-20">
       {/* 상단 히어로 */}

--- a/src/pages/StudyGroupPage.tsx
+++ b/src/pages/StudyGroupPage.tsx
@@ -1,0 +1,108 @@
+import { Button } from '@/components/common'
+import { SearchInput } from '@/components/search'
+import { StudyCard, StudySection } from '@/components/studygroup'
+import type { StudyGroupResponseType } from '@/types'
+import { Plus } from 'lucide-react'
+import { useEffect, useState } from 'react'
+
+export function StudyGroupPage() {
+  const [studies, setStudies] = useState<StudyGroupResponseType[]>([])
+
+  useEffect(() => {
+    fetch('/api/v1/study-groups')
+      .then((res) => res.json())
+      .then((data) => setStudies(data))
+  }, [])
+
+  const ongoingStudies = studies.filter((s) => s.status === 'ONGOING')
+  const pendingStudies = studies.filter((s) => s.status === 'PENDING')
+  const endedStudies = studies.filter((s) => s.status === 'ENDED')
+
+  const mapToCardProps = (study: StudyGroupResponseType) => {
+    const myReview = study.reviews.find((r) => r.is_mine)
+    return {
+      image: study.profile_img_url || '/placeholder.png',
+      name: study.name,
+      statusBadge:
+        study.status === 'PENDING'
+          ? '대기중'
+          : study.status === 'ONGOING'
+            ? '진행중'
+            : '종료됨',
+      statusColor:
+        study.status === 'ONGOING'
+          ? 'bg-success-500'
+          : study.status === 'ENDED'
+            ? 'bg-danger-500'
+            : 'bg-custom-gray-500',
+      roleBadge: study.is_leader ? '리더' : undefined,
+      memberCount: `${study.current_headcount}/${study.max_headcount}명`,
+      dateRange: `${study.start_at} ~ ${study.end_at}`,
+      lectures: study.lectures.map((l) => ({
+        title: l.title,
+        instructor: l.instructor,
+      })),
+      variant: (study.status === 'ENDED' ? 'completed' : 'default') as
+        | 'default'
+        | 'completed',
+      rating: myReview ? myReview.star_rating : 0,
+      reviewStatus: (myReview ? 'done' : 'none') as 'none' | 'done',
+    }
+  }
+
+  return (
+    <div className="flex flex-col gap-8 p-8">
+      <header className="mb-6 flex w-full flex-col md:flex-row md:items-center md:justify-between">
+        <div className="flex flex-col gap-2">
+          <h2>스터디 그룹</h2>
+          <div className="flex flex-col sm:flex-row">
+            <p className="mr-1">함께 공부하며 성장하는 스터디 그룹에</p>
+            <p>참여해보세요</p>
+          </div>
+        </div>
+        <Button variant="primary" className="mt-4 w-fit md:mt-0">
+          <Plus size={16} className="mr-2" />새 스터디 만들기
+        </Button>
+      </header>
+      <SearchInput />
+      <section className="flex flex-col gap-8">
+        {ongoingStudies.length > 0 && (
+          <StudySection
+            name="진행중인 스터디"
+            description="현재 활발히 진행되고 있는 스터디 그룹들"
+            badgeText={`${ongoingStudies.length}개 진행중`}
+            badgeColor="bg-success-100 text-success-700"
+          >
+            {ongoingStudies.map((study) => (
+              <StudyCard key={study.id} {...mapToCardProps(study)} />
+            ))}
+          </StudySection>
+        )}
+        {pendingStudies.length > 0 && (
+          <StudySection
+            name="대기중 스터디"
+            description="스터디 기간이 시작되지 않은 스터디 그룹들"
+            badgeText={`${pendingStudies.length}개 대기중`}
+            badgeColor="bg-custom-gray-100 text-custom-gray-600"
+          >
+            {pendingStudies.map((study) => (
+              <StudyCard key={study.id} {...mapToCardProps(study)} />
+            ))}
+          </StudySection>
+        )}
+        {endedStudies.length > 0 && (
+          <StudySection
+            name="완료된 스터디"
+            description="성공적으로 마무리된 스터디 그룹들"
+            badgeText={`${endedStudies.length}개 종료됨`}
+            badgeColor="bg-danger-100 text-danger-600"
+          >
+            {endedStudies.map((study) => (
+              <StudyCard key={study.id} {...mapToCardProps(study)} />
+            ))}
+          </StudySection>
+        )}
+      </section>
+    </div>
+  )
+}

--- a/src/pages/index.ts
+++ b/src/pages/index.ts
@@ -1,1 +1,2 @@
-//pages
+export * from './StudyDetailPage'
+export * from './StudyGroupPage'

--- a/src/routes/AppRoutes.tsx
+++ b/src/routes/AppRoutes.tsx
@@ -1,14 +1,13 @@
 import { Layout } from '@/components/layout'
-import StudyDetailPage from '@/pages/StudyDetailPage'
+import { StudyDetailPage, StudyGroupPage } from '@/pages'
 import { Route, Routes } from 'react-router'
 
 export function AppRoutes() {
   return (
     <Routes>
       <Route element={<Layout />}>
-        {/* 이곳에 라우팅 추가하기 */}
+        <Route index element={<StudyGroupPage />} />
         <Route path="study-groups/:groupId" element={<StudyDetailPage />} />
-        <Route index element={<main />} />
       </Route>
     </Routes>
   )

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -1,1 +1,4 @@
+export * from './chat'
+export * from './studygroup'
+export * from './studygroup-detail'
 export * from './userInformation'

--- a/src/types/studygroup-detail.ts
+++ b/src/types/studygroup-detail.ts
@@ -9,8 +9,8 @@ export interface StudyGroupLectureType {
   id: number
   title: string
   instructor: string
-  thumbnail_img_url: string
-  url_link: string
+  thumbnail_img_url?: string
+  url_link?: string
 }
 
 // 스터디 그룹 멤버 정보

--- a/src/types/studygroup.ts
+++ b/src/types/studygroup.ts
@@ -1,0 +1,22 @@
+import type { StudyGroupLectureType, StudyGroupStatus } from '@/types'
+
+export interface StudyGroupResponseType {
+  id: number
+  name: string
+  is_leader: boolean
+  start_at: string
+  end_at: string
+  max_headcount: number
+  current_headcount: number
+  profile_img_url: string | null
+  status: StudyGroupStatus
+  lectures: StudyGroupLectureType[]
+  reviews: StudyGroupReviewType[]
+}
+
+export interface StudyGroupReviewType {
+  id: number
+  is_mine: boolean
+  star_rating: number
+  content: string
+}


### PR DESCRIPTION
## ✨ PR 개요

<!-- 어떤 작업을 했는지 간략히 요약 -->
스터디 그룹 페이지 UI + MSW 연결

## 📌 관련 이슈

<!-- Closes #이슈번호 -->

Closes #68 

## 🧩 작업 내용 (주요 변경사항)
- 헤더 UI 수정
- `StudyCard` 컴포넌트와 하위 컴포넌트들 생성
- `StudySection` 컴포넌트 생성
- `mocks` 폴더에 MSW mockdata와 핸들러 추가
- `types` 폴더에 필요한 타입 추가
- `StudyGroupPage`에 컴포넌트들 배치 후 반응형 적용
- 배럴 파일 추가/수정

## 💬 리뷰 포인트

<!-- 특히 봐줬으면 하는 부분 (예: 상태관리 로직 구조 괜찮은지 봐주세요) -->

## 📸 스크린샷 (선택)

<!-- UI 변경이 있다면 캡처나 GIF 첨부 -->

https://github.com/user-attachments/assets/048fe22d-5fb0-4b1f-9c43-d9f145d7308b

## 🧠 기타 참고사항

<!-- 추가로 알아야 할 점 (예: 임시로 넣은 더미 데이터 있음) -->

## ✅ PR 체크리스트

- [x] 커밋 컨벤션 준수 (예: `feat: 로그인 구현`)
- [x] 로컬에서 실행 확인 완료
