### PR TITLE
style: 토스트 위치 우측 상단으로 고정 (#73)

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -6,7 +6,7 @@ function App() {
     <>
       <AppRoutes />
       <ToastContainer
-        position="top-center"
+        position="top-right"
         autoClose={3000}
         icon={false}
         closeButton={false}

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -6,7 +6,7 @@ function App() {
     <>
       <AppRoutes />
       <ToastContainer
-        position="top-right"
+        position="top-center"
         autoClose={3000}
         icon={false}
         closeButton={false}

--- a/src/lib/toast.tsx
+++ b/src/lib/toast.tsx
@@ -2,7 +2,7 @@ import { toast, type ToastOptions, Slide } from 'react-toastify'
 import { ToastAlert } from '@/components/common'
 
 const defaultOptions: ToastOptions = {
-  position: 'top-left',
+  position: 'top-center',
   autoClose: 5000,
   hideProgressBar: false,
   closeOnClick: false,

--- a/src/lib/toast.tsx
+++ b/src/lib/toast.tsx
@@ -2,7 +2,7 @@ import { toast, type ToastOptions, Slide } from 'react-toastify'
 import { ToastAlert } from '@/components/common'
 
 const defaultOptions: ToastOptions = {
-  position: 'top-center',
+  position: 'top-right',
   autoClose: 5000,
   hideProgressBar: false,
   closeOnClick: false,


### PR DESCRIPTION
## ✨ PR 개요

<!-- 어떤 작업을 했는지 간략히 요약 -->
토스트 위치 속성을 `position="top-right"`로 고정

## 📌 관련 이슈

<!-- Closes #이슈번호 -->

Closes #73 

## 💬 리뷰 포인트

<!-- 특히 봐줬으면 하는 부분 (예: 상태관리 로직 구조 괜찮은지 봐주세요) -->

## 📸 스크린샷 (선택)

<!-- UI 변경이 있다면 캡처나 GIF 첨부 -->

## 🧠 기타 참고사항

<!-- 추가로 알아야 할 점 (예: 임시로 넣은 더미 데이터 있음) -->
원래 센터로 교체 예정이었으나 1팀과 대화해본 결과 특정 라우트에서만 토스트를 중앙에 띄우기로 결정

## ✅ PR 체크리스트

- [x] 커밋 컨벤션 준수 (예: `feat: 로그인 구현`)
- [x] 로컬에서 실행 확인 완료
