### PR TITLE
Feature: 스케줄 상세 모달 UI 구현 및 캘린더 클릭 연동

### DIFF
--- a/src/components/schedule-calendar/ScheduleCalendar.tsx
+++ b/src/components/schedule-calendar/ScheduleCalendar.tsx
@@ -7,6 +7,8 @@ import {
   CustomToolbar,
   ScheduleEventItem,
 } from '@/components/schedule-calendar'
+import { mockSchedules } from '@/mocks/data/studygroup/schedule'
+import type { StudyScheduleDetailType } from '@/types'
 
 // 임시 데이터
 export interface ScheduleEvent {
@@ -27,13 +29,25 @@ const mockEvents: ScheduleEvent[] = [
   },
 ]
 
-export function ScheduleCalendar() {
+interface ScheduleCalendarProps {
+  onScheduleClick?: (schedule: StudyScheduleDetailType) => void
+}
+
+export function ScheduleCalendar({ onScheduleClick }: ScheduleCalendarProps) {
   const [month, setMonth] = useState(new Date())
   const formats = { monthHeaderFormat: 'yyyy년 MM월' }
 
   // 월 변경 핸들러
   const handleMonthNavigate = (newDate: Date) => {
     setMonth(newDate)
+  }
+
+  // 스케줄 일정 클릭 시 상세 mock 데이터 조회 및 전달
+  const handleSelectScheduleDetail = (event: ScheduleEvent) => {
+    const detail = mockSchedules.find((schedule) => schedule.id === event.id)
+    if (detail && onScheduleClick) {
+      onScheduleClick(detail)
+    }
   }
 
   return (
@@ -55,6 +69,7 @@ export function ScheduleCalendar() {
           event: ScheduleEventItem,
         }}
         showAllEvents
+        onSelectEvent={handleSelectScheduleDetail}
       />
     </div>
   )

--- a/src/components/studygroup-detail/StudyScheduleCalendar.tsx
+++ b/src/components/studygroup-detail/StudyScheduleCalendar.tsx
@@ -1,11 +1,18 @@
 import { Button } from '@/components/common'
 import { ScheduleCalendar } from '@/components/schedule-calendar'
-import { ScheduleCreateModal } from '@/components/studygroup-detail/modal'
+import {
+  ScheduleCreateModal,
+  ScheduleDetailModal,
+} from '@/components/studygroup-detail/modal'
+import type { StudyScheduleDetailType } from '@/types'
 import { Plus } from 'lucide-react'
 import { useState } from 'react'
 
 export function StudyScheduleCalendar() {
   const [isCreateOpen, setIsCreateOpen] = useState(false)
+  const [isDetailOpen, setIsDetailOpen] = useState(false)
+  const [selectedSchedule, setSelectedSchedule] =
+    useState<StudyScheduleDetailType | null>(null)
 
   const handleOpenCreateModal = () => {
     setIsCreateOpen(true)
@@ -13,6 +20,26 @@ export function StudyScheduleCalendar() {
 
   const handleCloseCreateModal = () => {
     setIsCreateOpen(false)
+  }
+
+  const handleScheduleClick = (schedule: StudyScheduleDetailType) => {
+    setSelectedSchedule(schedule)
+    setIsDetailOpen(true)
+  }
+
+  const handleCloseDetailModal = () => {
+    setIsDetailOpen(false)
+    setSelectedSchedule(null)
+  }
+
+  const handleEditSchedule = () => {
+    // 수정 예정
+    handleCloseDetailModal()
+  }
+
+  const handleDeleteSchedule = () => {
+    // 수정 예정
+    handleCloseDetailModal()
   }
 
   return (
@@ -28,13 +55,25 @@ export function StudyScheduleCalendar() {
           <span>스케줄 추가</span>
         </Button>
       </div>
-      <ScheduleCalendar />
+
+      {/* 스케줄 상세 모달 */}
+      <ScheduleCalendar onScheduleClick={handleScheduleClick} />
 
       {/* 새 스케줄 추가 모달 */}
       <ScheduleCreateModal
         isOpen={isCreateOpen}
         onClose={handleCloseCreateModal}
       />
+
+      {selectedSchedule && (
+        <ScheduleDetailModal
+          isOpen={isDetailOpen}
+          onClose={handleCloseDetailModal}
+          schedule={selectedSchedule}
+          onEdit={handleEditSchedule}
+          onDelete={handleDeleteSchedule}
+        />
+      )}
     </section>
   )
 }

--- a/src/components/studygroup-detail/modal/ScheduleDetailModal.tsx
+++ b/src/components/studygroup-detail/modal/ScheduleDetailModal.tsx
@@ -1,4 +1,5 @@
 import { Badge, Button, Modal } from '@/components/common'
+import { useBodyScrollLock } from '@/hooks'
 import type { StudyScheduleDetailType } from '@/types'
 import { Calendar, Clock3, UserRound } from 'lucide-react'
 
@@ -17,6 +18,8 @@ export function ScheduleDetailModal({
   onEdit,
   onDelete,
 }: ScheduleDetailModalProps) {
+  useBodyScrollLock(isOpen)
+
   const handleClickEdit = () => {
     onEdit(schedule)
   }

--- a/src/components/studygroup-detail/modal/ScheduleDetailModal.tsx
+++ b/src/components/studygroup-detail/modal/ScheduleDetailModal.tsx
@@ -1,0 +1,101 @@
+import { Badge, Button, Modal } from '@/components/common'
+import type { StudyScheduleDetailType } from '@/types'
+import { Calendar, Clock3, UserRound } from 'lucide-react'
+
+interface ScheduleDetailModalProps {
+  isOpen: boolean
+  onClose: () => void
+  schedule: StudyScheduleDetailType
+  onEdit: (schedule: StudyScheduleDetailType) => void
+  onDelete: (scheduleId: number) => void
+}
+
+export function ScheduleDetailModal({
+  isOpen,
+  onClose,
+  schedule,
+  onEdit,
+  onDelete,
+}: ScheduleDetailModalProps) {
+  const handleClickEdit = () => {
+    onEdit(schedule)
+  }
+
+  const handleClickDelete = () => {
+    onDelete(schedule.id)
+  }
+
+  const participants = schedule.participants
+  const participantCount = participants.length
+
+  return (
+    <Modal
+      isOpen={isOpen}
+      onClose={onClose}
+      title="스케줄 상세"
+      wrapperClassName="w-screen rounded-none sm:rounded-xl sm:w-[70vw] sm:max-w-[673px] h-screen h-dvh sm:h-auto sm:max-h-[80vh] p-0 m-0 "
+      innerClassName="mb-0 p-6 justify-start items-start"
+      titleClassName="p-6 border-b border-custom-gray-200"
+    >
+      <p className="text-custom-gray-900 text-lg">{schedule.title}</p>
+
+      <div className="flex w-full flex-col gap-2">
+        <p className="text-custom-gray-700 text-sm font-medium">스터디 목표</p>
+        <p className="text-custom-gray-700 bg-custom-gray-50 rounded-lg p-4">
+          {schedule.objective}
+        </p>
+      </div>
+
+      <div className="flex w-full gap-4">
+        <div className="flex flex-1 flex-col gap-2">
+          <p className="text-custom-gray-700 text-sm font-medium">
+            스터디 날짜
+          </p>
+          <p className="text-custom-gray-700 inline-flex items-center gap-2 text-sm font-medium">
+            <Calendar className="text-custom-gray-400 h-4 w-4" />
+            {schedule.session_date}
+          </p>
+        </div>
+
+        <div className="flex flex-1 flex-col gap-2">
+          <p className="text-custom-gray-700 text-sm font-medium">
+            스터디 시간
+          </p>
+          <p className="text-custom-gray-700 inline-flex items-center gap-2 text-sm font-medium">
+            <Clock3 className="text-custom-gray-400 h-4 w-4" />
+            {schedule.start_time} ~ {schedule.end_time}
+          </p>
+        </div>
+      </div>
+
+      <div className="flex w-full flex-col gap-2">
+        <p className="text-custom-gray-700 text-sm font-medium">
+          참여자 목록 ({participantCount}명)
+        </p>
+        <ul className="border-custom-gray-200 flex max-h-[192px] min-h-24 flex-col gap-2 overflow-y-auto rounded-lg border p-4">
+          <li className="flex items-center gap-3">
+            <span className="bg-primary-100 centralize h-8 w-8 rounded-full">
+              <UserRound className="text-primary-600 h-[14px] w-[14px]" />
+            </span>
+            <span className="text-sm">김개발</span>
+            <Badge className="h-6 rounded-sm">리더</Badge>
+          </li>
+        </ul>
+      </div>
+
+      <div className="border-custom-gray-200 flex w-full items-center justify-between gap-3 border-t pt-6">
+        <span className="text-custom-gray-500 text-xs">
+          생성일: {schedule.created_at}
+        </span>
+        <div className="flex gap-3">
+          <Button variant="primary" type="button" onClick={handleClickEdit}>
+            수정
+          </Button>
+          <Button variant="danger" type="button" onClick={handleClickDelete}>
+            삭제
+          </Button>
+        </div>
+      </div>
+    </Modal>
+  )
+}

--- a/src/components/studygroup-detail/modal/index.ts
+++ b/src/components/studygroup-detail/modal/index.ts
@@ -1,1 +1,2 @@
 export * from './ScheduleCreateModal'
+export * from './ScheduleDetailModal'


### PR DESCRIPTION
## ✨ PR 개요

스케줄 상세 모달 UI 구현 및 캘린더 클릭 연동

## 📌 관련 이슈

Closes #80

## 🧩 작업 내용 (주요 변경사항)

- `ScheduleDetailModal` 컴포넌트 기본 UI 구현
- 수정/삭제 버튼에 콜백만 연결(기능 구현은 별도 이슈 예정)
- `ScheduleCalendar`에서 `onScheduleClick` props 추가하여 상세 데이터 전달
- `StudyScheduleCalendar`에서 상세 모달 제어 로직 추가

## 💬 리뷰 포인트

## 📸 스크린샷 (선택)

https://github.com/user-attachments/assets/868ca64d-f9fe-42bb-81b2-6f5bf550b955

## 🧠 기타 참고사항

## ✅ PR 체크리스트

- [ ] 커밋 컨벤션 준수 (예: `feat: 로그인 구현`)
- [ ] 불필요한 console.log 제거
- [ ] 로컬에서 실행 확인 완료
