### PR TITLE
style: 마크다운 에디터 UI 수정 (#89)

### DIFF
--- a/src/components/common/IconDropdown.tsx
+++ b/src/components/common/IconDropdown.tsx
@@ -45,7 +45,7 @@ export function IconDropdown({
         onClick={toggle}
         disabled={disabled}
         className={cn(
-          'remove-focus-outline hover:bg-custom-gray-100 centralize h-7 w-7 rounded transition',
+          'remove-focus-outline hover:bg-custom-gray-100 centralize text-custom-gray-600 h-7 w-7 cursor-pointer rounded transition',
           disabled && 'cursor-not-allowed opacity-50'
         )}
       >

--- a/src/components/markdown/EditorHeader.tsx
+++ b/src/components/markdown/EditorHeader.tsx
@@ -12,7 +12,7 @@ export function EditorHeader({
   insertMarkdown,
 }: EditorHeaderProps) {
   return (
-    <header className="bg-custom-gray-50 border-custom-gray-200 flex h-22 flex-col justify-evenly border-b px-4 sm:h-12 sm:flex-row sm:items-center sm:justify-between">
+    <header className="bg-custom-gray-50 border-custom-gray-200 flex h-22 flex-col justify-evenly rounded-t-lg border-b px-4 sm:h-12 sm:flex-row sm:items-center sm:justify-between">
       <EditorTab mode={mode} setMode={setMode} />
       {mode === 'write' && <Toolbar insertMarkdown={insertMarkdown} />}
     </header>

--- a/src/components/markdown/MarkdownExample.tsx
+++ b/src/components/markdown/MarkdownExample.tsx
@@ -1,6 +1,6 @@
 export function MarkdownExample() {
   return (
-    <div className="text-custom-gray-600 border-custom-gray-200 bg-custom-gray-50 flex h-18 flex-col justify-center gap-2 border-t px-4 text-xs font-medium sm:h-12 md:h-8 md:flex-row md:items-center md:justify-start">
+    <div className="text-custom-gray-600 border-custom-gray-200 bg-custom-gray-50 flex h-18 flex-col justify-center gap-2 rounded-b-lg border-t px-4 text-xs font-medium sm:h-12 md:h-8 md:flex-row md:items-center md:justify-start">
       <p className="font-normal">마크다운 문법을 사용할 수 있습니다.</p>
       <div className="flex flex-col gap-0.5 sm:flex-row md:gap-2">
         <div className="flex gap-2">


### PR DESCRIPTION
## ✨ PR 개요

<!-- 어떤 작업을 했는지 간략히 요약 -->
마크다운 에디터 UI 수정

## 📌 관련 이슈

<!-- Closes #이슈번호 -->

Closes #89 

## 🧩 작업 내용 (주요 변경사항)
- 툴바의 아이콘 드롭다운 트리거 아이콘들 색상 변경
- 에디터 헤더와 마크다운 예시 파일에 `rounded` 속성 적용

## 💬 리뷰 포인트

<!-- 특히 봐줬으면 하는 부분 (예: 상태관리 로직 구조 괜찮은지 봐주세요) -->

## 📸 스크린샷 (선택)

<!-- UI 변경이 있다면 캡처나 GIF 첨부 -->
<img width="1183" height="331" alt="image" src="https://github.com/user-attachments/assets/53090864-e9eb-4294-8215-71f8370040a0" />

## 🧠 기타 참고사항

<!-- 추가로 알아야 할 점 (예: 임시로 넣은 더미 데이터 있음) -->

## ✅ PR 체크리스트

- [x] 커밋 컨벤션 준수 (예: `feat: 로그인 구현`)
- [x] 불필요한 console.log 제거
- [x] 로컬에서 실행 확인 완료
