### PR TITLE
refactor: 스케줄 생성/수정 공통 폼(ScheduleForm) 분리 및 적용

### DIFF
--- a/src/components/studygroup-detail/modal/ScheduleCreateModal.tsx
+++ b/src/components/studygroup-detail/modal/ScheduleCreateModal.tsx
@@ -1,54 +1,29 @@
-import { Controller, useForm } from 'react-hook-form'
-import {
-  Badge,
-  Button,
-  Checkbox,
-  Dropdown,
-  Input,
-  Modal,
-  Textarea,
-} from '@/components/common'
-import { createTimeOptions } from '@/utils/format'
-import { DatePickerInput } from '@/components/date-picker/DatePickerInput'
 import { useBodyScrollLock } from '@/hooks'
-
-// 10분 단위 시간 옵션
-const TIME_OPTIONS = createTimeOptions(10)
+import { ScheduleFormModeType, type ScheduleFormValuesType } from '@/types'
+import { ScheduleForm } from '@/components/studygroup-detail/modal/ScheduleForm'
+import { Modal } from '@/components/common'
 
 interface ScheduleCreateModalProps {
   isOpen: boolean
   onClose: () => void
 }
 
-interface ScheduleFormValues {
-  // DatePicker는 Date 객체를 사용하므로 UI 폼에서는 Date 유지
-  // API 호출 시 yyyy-MM-dd 문자열(session_date)로 변환 예정
-  title: string
-  objective: string
-  date: Date | null
-  start_time: string
-  end_time: string
-  participants: number[]
-}
-
 export function ScheduleCreateModal({
   isOpen,
   onClose,
 }: ScheduleCreateModalProps) {
-  const { register, handleSubmit, control } = useForm<ScheduleFormValues>({
-    defaultValues: {
-      title: '',
-      objective: '',
-      date: null,
-      start_time: '',
-      end_time: '',
-      participants: [],
-    },
-  })
-
   useBodyScrollLock(isOpen)
 
-  const onSubmit = (data: ScheduleFormValues) => {
+  const defaultValues: ScheduleFormValuesType = {
+    title: '',
+    objective: '',
+    date: null,
+    start_time: '',
+    end_time: '',
+    participants: [],
+  }
+
+  const handleSubmit = (data: ScheduleFormValuesType) => {
     // MSW 연결 후 제거 예정
     // eslint-disable-next-line no-console
     console.log(data)
@@ -64,105 +39,12 @@ export function ScheduleCreateModal({
       innerClassName="mb-0 p-6 justify-start"
       titleClassName="p-6 border-b border-custom-gray-200"
     >
-      <form
-        onSubmit={handleSubmit(onSubmit)}
-        className="flex w-full flex-col gap-6"
-      >
-        <Input
-          label="스케줄명"
-          placeholder="스케줄 제목을 입력하세요"
-          required
-          {...register('title')}
-        />
-
-        <Textarea
-          label="스터디 목표"
-          placeholder="이번 스터디에서 달성하고자 하는 목표를 입력하세요"
-          required
-          {...register('objective')}
-        />
-
-        <Controller
-          control={control}
-          name="date"
-          rules={{ required: '스터디 날짜를 선택해주세요' }}
-          render={({ field, fieldState }) => (
-            <DatePickerInput
-              label="스터디 날짜"
-              value={field.value ?? undefined}
-              // DatePicker는 undefined를 사용하지만, RHF에서는 null로 관리
-              onChange={(date) => field.onChange(date ?? null)}
-              required
-              error={fieldState.error?.message}
-            />
-          )}
-        />
-
-        <div className="flex gap-3">
-          <div className="flex-1 space-y-1.5">
-            <p className="text-custom-gray-700 text-sm leading-none font-medium">
-              시작 시간 <span className="text-danger-500">*</span>
-            </p>
-            <Controller
-              control={control}
-              name="start_time"
-              rules={{ required: '시작 시간을 선택해주세요' }}
-              render={({ field }) => (
-                <Dropdown
-                  options={TIME_OPTIONS}
-                  value={field.value}
-                  onChange={field.onChange}
-                  placeholder="00:00"
-                />
-              )}
-            />
-          </div>
-
-          <div className="flex-1 space-y-1.5">
-            <p className="text-custom-gray-700 text-sm leading-none font-medium">
-              종료 시간 <span className="text-danger-500">*</span>
-            </p>
-            <Controller
-              control={control}
-              name="end_time"
-              rules={{ required: '종료 시간을 선택해주세요' }}
-              render={({ field }) => (
-                <Dropdown
-                  options={TIME_OPTIONS}
-                  value={field.value}
-                  onChange={field.onChange}
-                  placeholder="00:00"
-                />
-              )}
-            />
-          </div>
-        </div>
-
-        <div className="flex flex-col space-y-1.5">
-          <p className="text-custom-gray-700 text-sm font-medium">
-            참여자 선택 <span className="text-danger-500">*</span>
-          </p>
-          <ul className="border-custom-gray-200 flex max-h-[192px] min-h-24 flex-col gap-2 overflow-y-auto rounded-lg border p-4">
-            <li>
-              <Checkbox label="김개발" shape="square" />
-            </li>
-            <li className="flex gap-2">
-              <Checkbox label="김개발" shape="square" />
-              <Badge variant="default">리더</Badge>
-            </li>
-          </ul>
-          <p className="text-custom-gray-500 text-xs">선택된 참여자: 0명</p>
-        </div>
-
-        <div className="border-custom-gray-200 flex justify-end gap-3 border-t pt-6">
-          <Button variant="outline" type="button" onClick={onClose}>
-            취소
-          </Button>
-          <Button variant="primary" type="submit">
-            추가하기
-          </Button>
-        </div>
-      </form>
+      <ScheduleForm
+        mode={ScheduleFormModeType.CREATE}
+        defaultValues={defaultValues}
+        onSubmit={handleSubmit}
+        onCancel={onClose}
+      />
     </Modal>
   )
 }

--- a/src/components/studygroup-detail/modal/ScheduleEditModal.tsx
+++ b/src/components/studygroup-detail/modal/ScheduleEditModal.tsx
@@ -1,21 +1,12 @@
-import {
-  Badge,
-  Button,
-  Checkbox,
-  Dropdown,
-  Input,
-  Modal,
-  Textarea,
-} from '@/components/common'
-import { DatePickerInput } from '@/components/date-picker/DatePickerInput'
+import { Modal } from '@/components/common'
+import { ScheduleForm } from '@/components/studygroup-detail/modal/ScheduleForm'
 import { useBodyScrollLock } from '@/hooks'
-import type { StudyScheduleDetailType } from '@/types'
-import { createTimeOptions } from '@/utils'
+import {
+  ScheduleFormModeType,
+  type ScheduleFormValuesType,
+  type StudyScheduleDetailType,
+} from '@/types'
 import { format, parseISO } from 'date-fns'
-import { Controller, useForm } from 'react-hook-form'
-
-// 10분 단위 시간 옵션
-const TIME_OPTIONS = createTimeOptions(10)
 
 interface ScheduleEditModalProps {
   isOpen: boolean
@@ -24,35 +15,24 @@ interface ScheduleEditModalProps {
   schedule: StudyScheduleDetailType
 }
 
-interface ScheduleFormValues {
-  title: string
-  objective: string
-  date: Date | null
-  start_time: string
-  end_time: string
-  participants: number[]
-}
-
 export function ScheduleEditModal({
   isOpen,
   onClose,
   onSave,
   schedule,
 }: ScheduleEditModalProps) {
-  const { register, handleSubmit, control } = useForm<ScheduleFormValues>({
-    defaultValues: {
-      title: schedule.title,
-      objective: schedule.objective,
-      date: schedule.session_date ? parseISO(schedule.session_date) : null,
-      start_time: schedule.start_time,
-      end_time: schedule.end_time,
-      participants: schedule.participants.map((participant) => participant.id),
-    },
-  })
-
   useBodyScrollLock(isOpen)
 
-  const onSubmit = (data: ScheduleFormValues) => {
+  const defaultValues: ScheduleFormValuesType = {
+    title: schedule.title,
+    objective: schedule.objective,
+    date: schedule.session_date ? parseISO(schedule.session_date) : null,
+    start_time: schedule.start_time,
+    end_time: schedule.end_time,
+    participants: schedule.participants.map((participant) => participant.id),
+  }
+
+  const handleSubmit = (data: ScheduleFormValuesType) => {
     const updated: StudyScheduleDetailType = {
       ...schedule,
       title: data.title,
@@ -76,104 +56,12 @@ export function ScheduleEditModal({
       innerClassName="mb-0 p-6 justify-start"
       titleClassName="p-6 border-b border-custom-gray-200"
     >
-      <form
-        onSubmit={handleSubmit(onSubmit)}
-        className="flex w-full flex-col gap-6"
-      >
-        <Input
-          label="스케줄명"
-          placeholder="스케줄 제목을 입력하세요"
-          required
-          {...register('title')}
-        />
-
-        <Textarea
-          label="스터디 목표"
-          placeholder="이번 스터디에서 달성하고자 하는 목표를 입력하세요"
-          required
-          {...register('objective')}
-        />
-
-        <Controller
-          control={control}
-          name="date"
-          rules={{ required: '스터디 날짜를 선택해주세요' }}
-          render={({ field, fieldState }) => (
-            <DatePickerInput
-              label="스터디 날짜"
-              value={field.value ?? undefined}
-              onChange={(date) => field.onChange(date ?? null)}
-              required
-              error={fieldState.error?.message}
-            />
-          )}
-        />
-
-        <div className="flex gap-3">
-          <div className="flex-1 space-y-1.5">
-            <p className="text-custom-gray-700 text-sm leading-none font-medium">
-              시작 시간 <span className="text-danger-500">*</span>
-            </p>
-            <Controller
-              control={control}
-              name="start_time"
-              rules={{ required: '시작 시간을 선택해주세요' }}
-              render={({ field }) => (
-                <Dropdown
-                  options={TIME_OPTIONS}
-                  value={field.value}
-                  onChange={field.onChange}
-                  placeholder="00:00"
-                />
-              )}
-            />
-          </div>
-
-          <div className="flex-1 space-y-1.5">
-            <p className="text-custom-gray-700 text-sm leading-none font-medium">
-              종료 시간 <span className="text-danger-500">*</span>
-            </p>
-            <Controller
-              control={control}
-              name="end_time"
-              rules={{ required: '종료 시간을 선택해주세요' }}
-              render={({ field }) => (
-                <Dropdown
-                  options={TIME_OPTIONS}
-                  value={field.value}
-                  onChange={field.onChange}
-                  placeholder="00:00"
-                />
-              )}
-            />
-          </div>
-        </div>
-
-        <div className="flex flex-col space-y-1.5">
-          <p className="text-custom-gray-700 text-sm font-medium">
-            참여자 선택 <span className="text-danger-500">*</span>
-          </p>
-          <ul className="border-custom-gray-200 flex max-h-[192px] min-h-24 flex-col gap-2 overflow-y-auto rounded-lg border p-4">
-            <li>
-              <Checkbox label="김개발" shape="square" />
-            </li>
-            <li className="flex gap-2">
-              <Checkbox label="김개발" shape="square" />
-              <Badge variant="default">리더</Badge>
-            </li>
-          </ul>
-          <p className="text-custom-gray-500 text-xs">선택된 참여자: 0명</p>
-        </div>
-
-        <div className="border-custom-gray-200 flex justify-end gap-3 border-t pt-6">
-          <Button variant="outline" type="button" onClick={onClose}>
-            취소
-          </Button>
-          <Button variant="primary" type="submit">
-            수정하기
-          </Button>
-        </div>
-      </form>
+      <ScheduleForm
+        mode={ScheduleFormModeType.EDIT}
+        defaultValues={defaultValues}
+        onSubmit={handleSubmit}
+        onCancel={onClose}
+      />
     </Modal>
   )
 }

--- a/src/components/studygroup-detail/modal/ScheduleForm.tsx
+++ b/src/components/studygroup-detail/modal/ScheduleForm.tsx
@@ -1,0 +1,159 @@
+import {
+  Badge,
+  Button,
+  Checkbox,
+  Dropdown,
+  Input,
+  Textarea,
+} from '@/components/common'
+import { DatePickerInput } from '@/components/date-picker/DatePickerInput'
+import { ScheduleFormModeType, type ScheduleFormValuesType } from '@/types'
+
+import { createTimeOptions } from '@/utils'
+import { Controller, useForm } from 'react-hook-form'
+
+// 10분 단위 시간 옵션
+const TIME_OPTIONS = createTimeOptions(10)
+
+interface ScheduleFormProps {
+  mode: ScheduleFormModeType
+  defaultValues: ScheduleFormValuesType
+  onSubmit: (values: ScheduleFormValuesType) => void
+  onCancel: () => void
+}
+
+export function ScheduleForm({
+  mode,
+  defaultValues,
+  onSubmit,
+  onCancel,
+}: ScheduleFormProps) {
+  const {
+    register,
+    handleSubmit,
+    control,
+    formState: { errors },
+  } = useForm<ScheduleFormValuesType>({
+    defaultValues,
+  })
+
+  const submitLabel =
+    mode === ScheduleFormModeType.CREATE ? '추가하기' : '수정하기'
+
+  return (
+    <form
+      onSubmit={handleSubmit(onSubmit)}
+      className="flex w-full flex-col gap-6"
+    >
+      <Input
+        label="스케줄명"
+        placeholder="스케줄 제목을 입력하세요"
+        {...register('title', {
+          required: '스케줄명을 입력해주세요.',
+        })}
+      />
+      {errors.title && (
+        <p className="text-danger-500 text-xs">{errors.title.message}</p>
+      )}
+
+      <Textarea
+        label="스터디 목표"
+        placeholder="이번 스터디에서 달성하고자 하는 목표를 입력하세요"
+        {...register('objective', {
+          required: '스터디 목표를 입력해주세요.',
+        })}
+      />
+      {errors.objective && (
+        <p className="text-danger-500 text-xs">{errors.objective.message}</p>
+      )}
+
+      <Controller
+        control={control}
+        name="date"
+        rules={{ required: '스터디 날짜를 선택해주세요' }}
+        render={({ field, fieldState }) => (
+          <DatePickerInput
+            label="스터디 날짜"
+            value={field.value ?? undefined}
+            // DatePicker는 undefined를 사용하지만, RHF에서는 null로 관리
+            onChange={(date) => field.onChange(date ?? null)}
+            required
+            error={fieldState.error?.message}
+          />
+        )}
+      />
+
+      <div className="flex gap-3">
+        <div className="flex-1 space-y-1.5">
+          <p className="text-custom-gray-700 text-sm leading-none font-medium">
+            시작 시간 <span className="text-danger-500">*</span>
+          </p>
+          <Controller
+            control={control}
+            name="start_time"
+            rules={{ required: '시작 시간을 선택해주세요' }}
+            render={({ field }) => (
+              <Dropdown
+                options={TIME_OPTIONS}
+                value={field.value}
+                onChange={field.onChange}
+                placeholder="00:00"
+              />
+            )}
+          />
+          {errors.start_time && (
+            <p className="text-danger-500 text-xs">
+              {errors.start_time.message}
+            </p>
+          )}
+        </div>
+        <div className="flex-1 space-y-1.5">
+          <p className="text-custom-gray-700 text-sm leading-none font-medium">
+            종료 시간 <span className="text-danger-500">*</span>
+          </p>
+          <Controller
+            control={control}
+            name="end_time"
+            rules={{ required: '종료 시간을 선택해주세요' }}
+            render={({ field }) => (
+              <Dropdown
+                options={TIME_OPTIONS}
+                value={field.value}
+                onChange={field.onChange}
+                placeholder="00:00"
+              />
+            )}
+          />
+          {errors.end_time && (
+            <p className="text-danger-500 text-xs">{errors.end_time.message}</p>
+          )}
+        </div>
+      </div>
+
+      <div className="flex flex-col space-y-1.5">
+        <p className="text-custom-gray-700 text-sm font-medium">
+          참여자 선택 <span className="text-danger-500">*</span>
+        </p>
+        <ul className="border-custom-gray-200 flex max-h-[192px] min-h-24 flex-col gap-2 overflow-y-auto rounded-lg border p-4">
+          <li>
+            <Checkbox label="김개발" shape="square" />
+          </li>
+          <li className="flex gap-2">
+            <Checkbox label="김개발" shape="square" />
+            <Badge variant="default">리더</Badge>
+          </li>
+        </ul>
+        <p className="text-custom-gray-500 text-xs">선택된 참여자: 0명</p>
+      </div>
+
+      <div className="border-custom-gray-200 flex justify-end gap-3 border-t pt-6">
+        <Button variant="outline" type="button" onClick={onCancel}>
+          취소
+        </Button>
+        <Button variant="primary" type="submit">
+          {submitLabel}
+        </Button>
+      </div>
+    </form>
+  )
+}

--- a/src/types/study-schedule.ts
+++ b/src/types/study-schedule.ts
@@ -48,3 +48,21 @@ export interface UpdateStudyScheduleRequestType {
   end_time?: string
   participants?: number[]
 }
+
+// 스케줄 Form 타입
+export enum ScheduleFormModeType {
+  CREATE = 'create',
+  EDIT = 'edit',
+}
+
+// 공통 폼에서 사용하는 값 타입
+export interface ScheduleFormValuesType {
+  // DatePicker는 Date 객체를 사용하므로 UI 폼에서는 Date 유지
+  // API 호출 시 yyyy-MM-dd 문자열(session_date)로 변환 예정
+  title: string
+  objective: string
+  date: Date | null
+  start_time: string
+  end_time: string
+  participants: number[]
+}


### PR DESCRIPTION
## ✨ PR 개요

스케줄 생성/수정 공통 폼(ScheduleForm) 분리 및 적용

## 📌 관련 이슈

Closes #91

## 🧩 작업 내용 (주요 변경사항)

- ScheduleForm 컴포넌트 추가
- 기존 스케줄 생성/수정 모달 내부의 중복된 폼 제거 
- 스케줄 생성/수정 모달 공통 ScheduleForm 컴포넌트 적용

## 💬 리뷰 포인트

## 📸 스크린샷 (선택)

기존 스케줄 생성/수정 모달과 UI 변경 사항은 없습니다.

## 🧠 기타 참고사항

### 이후 예정 작업 (별도 Issue)
<img width="514" height="763" alt="스크린샷 2025-12-04 오후 9 37 03" src="https://github.com/user-attachments/assets/b3865c3d-89f4-4adf-8f07-3685423b3724" />

- Input/Textarea 공통 컴포넌트의 error UI 통합
(현재 ScheduleForm에서 필드 하단 `<p>`로 출력되는 에러 메시지를 공통 컴포넌트에서 관리하도록 개선하려고 합니다.)
- ScheduleForm의 에러 UI를 공통 컴포넌트 기반으로 정리

## ✅ PR 체크리스트

- [ ] 커밋 컨벤션 준수 (예: `feat: 로그인 구현`)
- [ ] 불필요한 console.log 제거
- [ ] 로컬에서 실행 확인 완료
