### PR TITLE
Feature: 스터디 스케줄 CRUD MSW 핸들러 추가

### DIFF
--- a/src/mocks/data/studygroup/index.ts
+++ b/src/mocks/data/studygroup/index.ts
@@ -1,1 +1,2 @@
 export * from './studygroup'
+export * from './schedule'

--- a/src/mocks/handler.ts
+++ b/src/mocks/handler.ts
@@ -1,6 +1,7 @@
 import { MSW_BASE_URL } from '@/constants'
 import {
   chatHandlers,
+  scheduleHandlers,
   studygroupHandler,
   userInformationHandler,
 } from '@/mocks/handlers'
@@ -17,4 +18,5 @@ export const handlers = [
   ...chatHandlers,
   ...reviewHandlers,
   ...studygroupHandler,
+  ...scheduleHandlers,
 ]

--- a/src/mocks/handlers/index.ts
+++ b/src/mocks/handlers/index.ts
@@ -1,3 +1,5 @@
 export * from './chat-handlers'
 export * from './studygroup-handler'
 export * from './user-handler'
+export * from './review-handlers'
+export * from './schedule-handlers'

--- a/src/mocks/handlers/schedule-handlers.ts
+++ b/src/mocks/handlers/schedule-handlers.ts
@@ -1,0 +1,165 @@
+import {
+  mockScheduleParticipants,
+  mockSchedules,
+  toScheduleListItem,
+} from '@/mocks/data/studygroup/schedule'
+import type {
+  CreateStudyScheduleRequestType,
+  ScheduleSuccessResponseType,
+  StudyScheduleDetailType,
+  UpdateStudyScheduleRequestType,
+} from '@/types'
+import { http, HttpResponse } from 'msw'
+
+// id 증가 유틸
+const getNextScheduleId = () =>
+  mockSchedules.length ? Math.max(...mockSchedules.map((s) => s.id)) + 1 : 1
+
+// 스케줄 목록 조회
+export const getStudySchedulesHandler = http.get(
+  '/api/v1/study-groups/:groupId/schedules',
+  ({ params }) => {
+    const { groupId } = params
+    const scheduleDetails = mockSchedules.filter(
+      (schedule) => schedule.group_id === Number(groupId)
+    )
+    const scheduleListItems = scheduleDetails.map(toScheduleListItem)
+
+    return HttpResponse.json(scheduleListItems, { status: 200 })
+  }
+)
+
+// 스케줄 생성
+export const createStudyScheduleHandler = http.post(
+  '/api/v1/study-groups/:groupId/schedules',
+  async ({ request, params }) => {
+    const body = (await request.json()) as CreateStudyScheduleRequestType
+    const now = new Date().toISOString()
+    const id = getNextScheduleId()
+
+    const participants = mockScheduleParticipants.filter((participant) =>
+      body.participants.includes(participant.id)
+    )
+
+    const newSchedule: StudyScheduleDetailType = {
+      id,
+      group_id: Number(params.groupId),
+      title: body.title,
+      objective: body.objective,
+      session_date: body.session_date,
+      start_time: body.start_time,
+      end_time: body.end_time,
+      created_at: now,
+      updated_at: now,
+      participants,
+    }
+
+    mockSchedules.push(newSchedule)
+
+    const response: ScheduleSuccessResponseType = {
+      detail: '스터디 스케줄 생성에 성공했습니다.',
+    }
+
+    return HttpResponse.json(response, { status: 200 })
+  }
+)
+
+// 스케줄 상세 조회
+export const getStudyScheduleDetailHandler = http.get(
+  '/api/v1/study-groups/:groupId/schedules/:scheduleId',
+  ({ params }) => {
+    const { groupId, scheduleId } = params
+    const scheduleDetail = mockSchedules.find(
+      (item) =>
+        item.group_id === Number(groupId) && item.id === Number(scheduleId)
+    )
+
+    if (!scheduleDetail) {
+      return HttpResponse.json(
+        { error_detail: '스터디 스케줄을 찾을 수 없습니다.' },
+        { status: 404 }
+      )
+    }
+
+    return HttpResponse.json(scheduleDetail, { status: 200 })
+  }
+)
+
+// 스케줄 수정
+export const updateStudyScheduleHandler = http.patch(
+  '/api/v1/study-groups/:groupId/schedules/:scheduleId',
+  async ({ request, params }) => {
+    const { groupId, scheduleId } = params
+    const body = (await request.json()) as UpdateStudyScheduleRequestType
+
+    const index = mockSchedules.findIndex(
+      (schedule) =>
+        schedule.group_id === Number(groupId) &&
+        schedule.id === Number(scheduleId)
+    )
+
+    if (index === -1) {
+      return HttpResponse.json(
+        { error_detail: '스터디 스케줄을 찾을 수 없습니다.' },
+        { status: 404 }
+      )
+    }
+
+    const now = new Date().toISOString()
+    const existing = mockSchedules[index]
+
+    const participants = body.participants
+      ? mockScheduleParticipants.filter((participant) =>
+          body.participants!.includes(participant.id)
+        )
+      : existing.participants
+
+    const updated: StudyScheduleDetailType = {
+      ...existing,
+      ...body,
+      participants,
+      updated_at: now,
+    }
+
+    mockSchedules[index] = updated
+
+    return HttpResponse.json(updated, { status: 200 })
+  }
+)
+
+// 스케줄 삭제
+export const deleteStudyScheduleHandler = http.delete(
+  '/api/v1/study-groups/:groupId/schedules/:scheduleId',
+  ({ params }) => {
+    const { groupId, scheduleId } = params
+
+    const index = mockSchedules.findIndex(
+      (schedule) =>
+        schedule.group_id === Number(groupId) &&
+        schedule.id === Number(scheduleId)
+    )
+
+    if (index === -1) {
+      return HttpResponse.json(
+        { error_detail: '스터디 스케줄을 찾을 수 없습니다.' },
+        { status: 404 }
+      )
+    }
+
+    mockSchedules.splice(index, 1)
+
+    const response: ScheduleSuccessResponseType = {
+      detail: '스터디 스케줄 삭제에 성공했습니다.',
+    }
+
+    return HttpResponse.json(response, { status: 200 })
+  }
+)
+
+export const scheduleHandlers = [
+  getStudySchedulesHandler,
+  createStudyScheduleHandler,
+  getStudyScheduleDetailHandler,
+  updateStudyScheduleHandler,
+  deleteStudyScheduleHandler,
+]


### PR DESCRIPTION
## ✨ PR 개요

스터디 스케줄 CRUD MSW 핸들러 추가

## 📌 관련 이슈

Closes #79

## 🧩 작업 내용 (주요 변경사항)

- 스터디 스케줄 CRUD MSW 핸들러 추가
- 목데이터 기반으로 스케줄 흐름 UI에서 테스트할 수 있도록 환경 구성

### 이후 예정 작업
- 스케줄 API 관련 TanStack Query 훅 연결

## 💬 리뷰 포인트

## 📸 스크린샷 (선택)

## 🧠 기타 참고사항
-  이번 PR은 스케줄 CRUD 핸들러 구축까지의 작업으로, 실제 UI와의 데이터 연동은 아직 포함되어 있지 않습니다.
-  테스트는 TanStack Query 훅 연결 이후 진행될 예정입니다.

## ✅ PR 체크리스트

- [ ] 커밋 컨벤션 준수 (예: `feat: 로그인 구현`)
- [ ] 불필요한 console.log 제거
- [ ] 로컬에서 실행 확인 완료
