### PR TITLE
feat: ScheduleForm 필드 에러 처리 공통 컴포넌트 기반으로 통합

### DIFF
--- a/src/components/studygroup-detail/modal/ScheduleForm.tsx
+++ b/src/components/studygroup-detail/modal/ScheduleForm.tsx
@@ -48,24 +48,22 @@ export function ScheduleForm({
       <Input
         label="스케줄명"
         placeholder="스케줄 제목을 입력하세요"
+        required
+        error={errors.title?.message}
         {...register('title', {
           required: '스케줄명을 입력해주세요.',
         })}
       />
-      {errors.title && (
-        <p className="text-danger-500 text-xs">{errors.title.message}</p>
-      )}
 
       <Textarea
         label="스터디 목표"
         placeholder="이번 스터디에서 달성하고자 하는 목표를 입력하세요"
+        required
+        error={errors.objective?.message}
         {...register('objective', {
           required: '스터디 목표를 입력해주세요.',
         })}
       />
-      {errors.objective && (
-        <p className="text-danger-500 text-xs">{errors.objective.message}</p>
-      )}
 
       <Controller
         control={control}


### PR DESCRIPTION
## ✨ PR 개요

에러 UI를 공통 컴포넌트에서 일관되게 처리하도록 리팩토링했습니다.

## 📌 관련 이슈

Closes #95

## 🧩 작업 내용 (주요 변경사항)

- ScheduleForm 내부의 `<p>` 기반 에러 메시지 출력 제거
- Input / Textarea의 error prop을 활용하도록 변경

## 💬 리뷰 포인트

## 📸 스크린샷 (선택)
<img width="576" height="819" alt="스크린샷 2025-12-05 오전 11 33 23" src="https://github.com/user-attachments/assets/83cb304f-457b-4ba8-a5e3-0c9101c06a68" />

## 🧠 기타 참고사항

<!-- 추가로 알아야 할 점 (예: 임시로 넣은 더미 데이터 있음) -->

## ✅ PR 체크리스트

- [ ] 커밋 컨벤션 준수 (예: `feat: 로그인 구현`)
- [ ] 불필요한 console.log 제거
- [ ] 로컬에서 실행 확인 완료
