### PR TITLE
refactor: 마크다운 에디터 코드 리팩토링 (#96)    

### DIFF
--- a/src/components/markdown/MarkdownEditor.tsx
+++ b/src/components/markdown/MarkdownEditor.tsx
@@ -1,33 +1,15 @@
-import { useRef, useState } from 'react'
+import { useState } from 'react'
 import {
   EditorHeader,
   EditorTextarea,
   MarkdownExample,
   Preview,
 } from '@/components/markdown'
+import { useMarkdownEditor } from '@/hooks'
 
 export function MarkdownEditor() {
+  const { value, setValue, textareaRef, insertMarkdown } = useMarkdownEditor()
   const [mode, setMode] = useState<'write' | 'preview'>('write')
-  const [value, setValue] = useState('')
-  const textareaRef = useRef<HTMLTextAreaElement | null>(null)
-
-  function insertMarkdown(before: string, after: string = '') {
-    const textarea = textareaRef.current
-    if (!textarea) return
-
-    const start = textarea.selectionStart
-    const end = textarea.selectionEnd
-
-    const selected = value.slice(start, end)
-    const replaced = before + (selected || '') + after
-
-    setValue(value.slice(0, start) + replaced + value.slice(end))
-
-    requestAnimationFrame(() => {
-      textarea.focus()
-      textarea.selectionStart = textarea.selectionEnd = start + replaced.length
-    })
-  }
 
   return (
     <div className="border-custom-gray-200 rounded-lg border">

--- a/src/components/markdown/ToolbarDropdown.tsx
+++ b/src/components/markdown/ToolbarDropdown.tsx
@@ -1,5 +1,5 @@
 import { IconDropdown } from '@/components/common'
-import { headingOptions, ListOptions } from '@/constants'
+import { headingOptions, listOptions } from '@/constants'
 import { Heading1Icon, ListIcon } from 'lucide-react'
 
 interface ToolbarDropdownProps {
@@ -14,17 +14,8 @@ export function ToolbarDropdownHeading({
       options={headingOptions}
       triggerIcon={<Heading1Icon />}
       onChange={(value) => {
-        switch (value) {
-          case 'h1':
-            insertMarkdown('# ')
-            break
-          case 'h2':
-            insertMarkdown('## ')
-            break
-          case 'h3':
-            insertMarkdown('### ')
-            break
-        }
+        const option = headingOptions.find((o) => o.value === value)
+        if (option) insertMarkdown(option.before)
       }}
     />
   )
@@ -33,17 +24,11 @@ export function ToolbarDropdownHeading({
 export function ToolbarDropdownList({ insertMarkdown }: ToolbarDropdownProps) {
   return (
     <IconDropdown
-      options={ListOptions}
+      options={listOptions}
       triggerIcon={<ListIcon />}
       onChange={(value) => {
-        switch (value) {
-          case 'unordered list':
-            insertMarkdown('- ')
-            break
-          case 'ordered list':
-            insertMarkdown('1. ')
-            break
-        }
+        const option = listOptions.find((o) => o.value === value)
+        if (option) insertMarkdown(option.before)
       }}
     />
   )

--- a/src/constants/toolbar.ts
+++ b/src/constants/toolbar.ts
@@ -11,6 +11,10 @@ import {
   ListIcon,
 } from 'lucide-react'
 
+type ToolbarDropdownOption = DropdownOption & {
+  before: string
+}
+
 export const TOOLBAR_BUTTONS = [
   { key: 'bold', before: '**', after: '**', Icon: BoldIcon },
   { key: 'italic', before: '*', after: '*', Icon: ItalicIcon },
@@ -18,13 +22,13 @@ export const TOOLBAR_BUTTONS = [
   { key: 'link', before: '[', after: '](https://)', Icon: LinkIcon },
 ]
 
-export const headingOptions: DropdownOption[] = [
-  { value: 'h1', Icon: Heading1Icon },
-  { value: 'h2', Icon: Heading2Icon },
-  { value: 'h3', Icon: Heading3Icon },
+export const headingOptions: ToolbarDropdownOption[] = [
+  { value: 'h1', Icon: Heading1Icon, before: '# ' },
+  { value: 'h2', Icon: Heading2Icon, before: '## ' },
+  { value: 'h3', Icon: Heading3Icon, before: '### ' },
 ]
 
-export const ListOptions: DropdownOption[] = [
-  { value: 'unordered list', Icon: ListIcon },
-  { value: 'ordered list', Icon: ListOrderedIcon },
+export const listOptions: ToolbarDropdownOption[] = [
+  { value: 'unordered list', Icon: ListIcon, before: '- ' },
+  { value: 'ordered list', Icon: ListOrderedIcon, before: '1. ' },
 ]

--- a/src/hooks/index.ts
+++ b/src/hooks/index.ts
@@ -1,4 +1,5 @@
 export * from './useDebounce'
+export * from './useMarkdownEditor'
 export * from './chat'
 export * from './common'
 export * from './queries'

--- a/src/hooks/useMarkdownEditor.ts
+++ b/src/hooks/useMarkdownEditor.ts
@@ -1,0 +1,37 @@
+import { useCallback, useRef, useState } from 'react'
+
+export function useMarkdownEditor() {
+  const [value, setValue] = useState('')
+  const textareaRef = useRef<HTMLTextAreaElement | null>(null)
+
+  const insertMarkdown = useCallback(
+    (before: string, after: string = '') => {
+      const textarea = textareaRef.current
+      if (!textarea) return
+
+      const start = textarea.selectionStart
+      const end = textarea.selectionEnd
+
+      const selected = value.slice(start, end)
+      const replaced = before + (selected || '') + after
+
+      setValue(value.slice(0, start) + replaced + value.slice(end))
+
+      requestAnimationFrame(() => {
+        if (!textareaRef.current) return
+        const next = start + replaced.length
+        textareaRef.current.focus()
+        textareaRef.current.selectionStart = next
+        textareaRef.current.selectionEnd = next
+      })
+    },
+    [value]
+  )
+
+  return {
+    value,
+    setValue,
+    textareaRef,
+    insertMarkdown,
+  }
+}

--- a/src/lib/markdown.ts
+++ b/src/lib/markdown.ts
@@ -1,28 +1,37 @@
-export function markdownToHtml(markdown: string): string {
-  let html: string = markdown
+function parseBold(text: string): string {
+  return text.replace(/\*\*(.+?)\*\*/g, '<strong>$1</strong>')
+}
 
-  html = html.replace(/\*\*(.+?)\*\*/g, '<strong>$1</strong>')
+function parseItalic(text: string): string {
+  return text.replace(/\*(.+?)\*/g, '<em>$1</em>')
+}
 
-  html = html.replace(/\*(.+?)\*/g, '<em>$1</em>')
+function parseInlineCode(text: string): string {
+  return text.replace(/`(.+?)`/g, '<code>$1</code>')
+}
 
-  html = html.replace(/`(.+?)`/g, '<code>$1</code>')
-
-  html = html.replace(
+function parseImages(text: string): string {
+  return text.replace(
     /!\[(.*?)\]\(([^)]*?)\)/g,
-    (_match: string, alt: string, url: string): string => {
-      return `<img src="${url}" alt="${alt || ''}" />`
-    }
+    (_, alt: string, url: string) => `<img src="${url}" alt="${alt || ''}" />`
   )
+}
 
-  html = html.replace(/\[(.+?)\]\((.+?)\)/g, '<a href="$2">$1</a>')
+function parseLinks(text: string): string {
+  return text.replace(/\[(.+?)\]\((.+?)\)/g, '<a href="$2">$1</a>')
+}
 
-  html = html.replace(/^# (.+)$/gm, '<h1>$1</h1>')
-  html = html.replace(/^## (.+)$/gm, '<h2>$1</h2>')
-  html = html.replace(/^### (.+)$/gm, '<h3>$1</h3>')
+function parseHeadings(text: string): string {
+  return text
+    .replace(/^# (.+)$/gm, '<h1>$1</h1>')
+    .replace(/^## (.+)$/gm, '<h2>$1</h2>')
+    .replace(/^### (.+)$/gm, '<h3>$1</h3>')
+}
 
-  html = html.replace(
+function parseUnorderedList(text: string): string {
+  return text.replace(
     /(^|\r?\n)((?:\s*- .+(?:\r?\n|$))+)/g,
-    (_m, prefix, block) => {
+    (_, prefix, block) => {
       const items = block
         .trim()
         .split(/\r?\n/)
@@ -33,10 +42,12 @@ export function markdownToHtml(markdown: string): string {
       return `${prefix}<ul>${items}</ul>`
     }
   )
+}
 
-  html = html.replace(
+function parseOrderedList(text: string): string {
+  return text.replace(
     /(^|\r?\n)((?:\d+\. .+(?:\r?\n|$))+)/g,
-    (_m, prefix, block) => {
+    (_, prefix, block) => {
       const items = block
         .trim()
         .split(/\r?\n/)
@@ -47,11 +58,27 @@ export function markdownToHtml(markdown: string): string {
       return `${prefix}<ol>${items}</ol>`
     }
   )
+}
 
-  html = html.replace(
+function parseLineBreaks(text: string): string {
+  return text.replace(
     /(?<!<\/ul>|<\/ol>|<\/li>|<\/h1>|<\/h2>|<\/h3>)\n/g,
     '<br/>'
   )
+}
+
+export function markdownToHtml(markdown: string): string {
+  let html = markdown
+
+  html = parseBold(html)
+  html = parseItalic(html)
+  html = parseInlineCode(html)
+  html = parseImages(html)
+  html = parseLinks(html)
+  html = parseHeadings(html)
+  html = parseUnorderedList(html)
+  html = parseOrderedList(html)
+  html = parseLineBreaks(html)
 
   return html
 }


### PR DESCRIPTION
## ✨ PR 개요

<!-- 어떤 작업을 했는지 간략히 요약 -->
멘토링 피드백 기반으로 마크다운 에디터 코드 리팩토링

## 📌 관련 이슈

<!-- Closes #이슈번호 -->

Closes #96 

## 🧩 작업 내용 (주요 변경사항)
- `insertMarkdown` 함수를 `useMarkdownEditor` 커스텀 훅으로 분리
- `ToolbarDropdown` 컴포넌트들에서 쓰이던 `headingOptions`와 `listOptions`에 `before` 속성을 추가해서 코드 단순화 
- 마크다운 파싱 로직을 개별 함수로 분리하여 모듈화

## 💬 리뷰 포인트

<!-- 특히 봐줬으면 하는 부분 (예: 상태관리 로직 구조 괜찮은지 봐주세요) -->

## 📸 스크린샷 (선택)

<!-- UI 변경이 있다면 캡처나 GIF 첨부 -->

## 🧠 기타 참고사항

<!-- 추가로 알아야 할 점 (예: 임시로 넣은 더미 데이터 있음) -->

## ✅ PR 체크리스트

- [x] 커밋 컨벤션 준수 (예: `feat: 로그인 구현`)
- [x] 로컬에서 실행 확인 완료
