### PR TITLE
feat: 스터디 스케줄 CRUD Query 바인딩 및 캘린더/모달 연동

### DIFF
--- a/src/components/schedule-calendar/ScheduleCalendar.tsx
+++ b/src/components/schedule-calendar/ScheduleCalendar.tsx
@@ -8,9 +8,12 @@ import {
   ScheduleEventItem,
 } from '@/components/schedule-calendar'
 import { mockSchedules } from '@/mocks/data/studygroup/schedule'
-import type { StudyScheduleDetailType } from '@/types'
+import type {
+  StudyScheduleDetailType,
+  StudyScheduleListItemType,
+} from '@/types'
+import { parseISO } from 'date-fns'
 
-// 임시 데이터
 export interface ScheduleEvent {
   id: number
   title: string
@@ -19,23 +22,32 @@ export interface ScheduleEvent {
   end: Date
 }
 
-const mockEvents: ScheduleEvent[] = [
-  {
-    id: 1,
-    title: '스터디 일정',
-    timeLabel: '18:30 ~ 20:30',
-    start: new Date(2025, 10, 25, 18, 30),
-    end: new Date(2025, 10, 25, 20, 30),
-  },
-]
-
 interface ScheduleCalendarProps {
+  schedules: StudyScheduleListItemType[]
   onScheduleClick?: (schedule: StudyScheduleDetailType) => void
 }
 
-export function ScheduleCalendar({ onScheduleClick }: ScheduleCalendarProps) {
+export function ScheduleCalendar({
+  schedules,
+  onScheduleClick,
+}: ScheduleCalendarProps) {
   const [month, setMonth] = useState(new Date())
   const formats = { monthHeaderFormat: 'yyyy년 MM월' }
+
+  // react-big-calendar는 start/end가 Date 객체인 이벤트 배열 요구
+  const toEvent = (schedule: StudyScheduleListItemType): ScheduleEvent => {
+    return {
+      id: schedule.id,
+      title: schedule.title,
+      timeLabel: `${schedule.start_time} ~ ${schedule.end_time}`,
+      // ISO 문자열(yyyy-MM-ddTHH:mm) → Date 변환
+      start: parseISO(`${schedule.session_date}T${schedule.start_time}`),
+      end: parseISO(`${schedule.session_date}T${schedule.end_time}`),
+    }
+  }
+
+  // API 스케줄 목록을 캘린더 이벤트 배열로 변환
+  const events = (schedules ?? []).map(toEvent)
 
   // 월 변경 핸들러
   const handleMonthNavigate = (newDate: Date) => {
@@ -59,7 +71,7 @@ export function ScheduleCalendar({ onScheduleClick }: ScheduleCalendarProps) {
         formats={formats}
         startAccessor="start"
         endAccessor="end"
-        events={mockEvents}
+        events={events}
         defaultView="month"
         views={['month']}
         selectable

--- a/src/components/studygroup-detail/StudyScheduleCalendar.tsx
+++ b/src/components/studygroup-detail/StudyScheduleCalendar.tsx
@@ -5,7 +5,10 @@ import {
   ScheduleDetailModal,
   ScheduleEditModal,
 } from '@/components/studygroup-detail/modal'
-import { useStudySchedules } from '@/hooks/study-schedule'
+import {
+  useDeleteStudySchedule,
+  useStudySchedules,
+} from '@/hooks/study-schedule'
 import type { StudyScheduleDetailType } from '@/types'
 import { Plus } from 'lucide-react'
 import { useState } from 'react'
@@ -22,6 +25,7 @@ export function StudyScheduleCalendar({ groupId }: StudyScheduleCalendarProps) {
     useState<StudyScheduleDetailType | null>(null)
 
   const { data: schedules } = useStudySchedules(groupId)
+  const { mutate: deleteSchedule } = useDeleteStudySchedule(groupId)
 
   const handleOpenCreateModal = () => {
     setIsCreateOpen(true)
@@ -46,11 +50,12 @@ export function StudyScheduleCalendar({ groupId }: StudyScheduleCalendarProps) {
   }
 
   const handleDeleteSchedule = (scheduleId: number) => {
-    // 삭제 API 연동 예정
-    // eslint-disable-next-line no-console
-    console.log(scheduleId)
-    setIsDetailOpen(false)
-    setSelectedSchedule(null)
+    deleteSchedule(scheduleId, {
+      onSuccess: () => {
+        setIsDetailOpen(false)
+        setSelectedSchedule(null)
+      },
+    })
   }
 
   const handleCloseEditModal = () => {

--- a/src/components/studygroup-detail/StudyScheduleCalendar.tsx
+++ b/src/components/studygroup-detail/StudyScheduleCalendar.tsx
@@ -5,6 +5,7 @@ import {
   ScheduleDetailModal,
   ScheduleEditModal,
 } from '@/components/studygroup-detail/modal'
+import { useStudySchedules } from '@/hooks/study-schedule'
 import type { StudyScheduleDetailType } from '@/types'
 import { Plus } from 'lucide-react'
 import { useState } from 'react'
@@ -19,6 +20,8 @@ export function StudyScheduleCalendar({ groupId }: StudyScheduleCalendarProps) {
   const [isEditOpen, setIsEditOpen] = useState(false)
   const [selectedSchedule, setSelectedSchedule] =
     useState<StudyScheduleDetailType | null>(null)
+
+  const { data: schedules } = useStudySchedules(groupId)
 
   const handleOpenCreateModal = () => {
     setIsCreateOpen(true)
@@ -76,7 +79,10 @@ export function StudyScheduleCalendar({ groupId }: StudyScheduleCalendarProps) {
       </div>
 
       {/* 스케줄 캘린더 */}
-      <ScheduleCalendar onScheduleClick={handleScheduleClick} />
+      <ScheduleCalendar
+        schedules={schedules ?? []}
+        onScheduleClick={handleScheduleClick}
+      />
 
       {/* 새 스케줄 추가 모달 */}
       <ScheduleCreateModal

--- a/src/components/studygroup-detail/StudyScheduleCalendar.tsx
+++ b/src/components/studygroup-detail/StudyScheduleCalendar.tsx
@@ -107,6 +107,7 @@ export function StudyScheduleCalendar({ groupId }: StudyScheduleCalendarProps) {
           onClose={handleCloseEditModal}
           schedule={selectedSchedule}
           onSave={handleSaveEditedSchedule}
+          groupId={groupId}
         />
       )}
     </section>

--- a/src/components/studygroup-detail/StudyScheduleCalendar.tsx
+++ b/src/components/studygroup-detail/StudyScheduleCalendar.tsx
@@ -9,7 +9,11 @@ import type { StudyScheduleDetailType } from '@/types'
 import { Plus } from 'lucide-react'
 import { useState } from 'react'
 
-export function StudyScheduleCalendar() {
+interface StudyScheduleCalendarProps {
+  groupId: number
+}
+
+export function StudyScheduleCalendar({ groupId }: StudyScheduleCalendarProps) {
   const [isCreateOpen, setIsCreateOpen] = useState(false)
   const [isDetailOpen, setIsDetailOpen] = useState(false)
   const [isEditOpen, setIsEditOpen] = useState(false)
@@ -78,6 +82,7 @@ export function StudyScheduleCalendar() {
       <ScheduleCreateModal
         isOpen={isCreateOpen}
         onClose={handleCloseCreateModal}
+        groupId={groupId}
       />
 
       {selectedSchedule && (

--- a/src/components/studygroup-detail/modal/ScheduleCreateModal.tsx
+++ b/src/components/studygroup-detail/modal/ScheduleCreateModal.tsx
@@ -1,18 +1,28 @@
 import { useBodyScrollLock } from '@/hooks'
-import { ScheduleFormModeType, type ScheduleFormValuesType } from '@/types'
+import {
+  ScheduleFormModeType,
+  type CreateStudyScheduleRequestType,
+  type ScheduleFormValuesType,
+} from '@/types'
 import { ScheduleForm } from '@/components/studygroup-detail/modal/ScheduleForm'
 import { Modal } from '@/components/common'
+import { useCreateStudySchedule } from '@/hooks/study-schedule'
+import { format } from 'date-fns'
 
 interface ScheduleCreateModalProps {
   isOpen: boolean
   onClose: () => void
+  groupId: number
 }
 
 export function ScheduleCreateModal({
   isOpen,
   onClose,
+  groupId,
 }: ScheduleCreateModalProps) {
   useBodyScrollLock(isOpen)
+
+  const { mutate } = useCreateStudySchedule(groupId)
 
   const defaultValues: ScheduleFormValuesType = {
     title: '',
@@ -24,10 +34,18 @@ export function ScheduleCreateModal({
   }
 
   const handleSubmit = (data: ScheduleFormValuesType) => {
-    // MSW 연결 후 제거 예정
-    // eslint-disable-next-line no-console
-    console.log(data)
-    onClose()
+    const payload: CreateStudyScheduleRequestType = {
+      title: data.title,
+      objective: data.objective,
+      session_date: data.date ? format(data.date, 'yyyy-MM-dd') : '',
+      start_time: data.start_time,
+      end_time: data.end_time,
+      participants: data.participants,
+    }
+
+    mutate(payload, {
+      onSuccess: onClose,
+    })
   }
 
   return (

--- a/src/components/studygroup-detail/modal/ScheduleEditModal.tsx
+++ b/src/components/studygroup-detail/modal/ScheduleEditModal.tsx
@@ -1,10 +1,12 @@
 import { Modal } from '@/components/common'
 import { ScheduleForm } from '@/components/studygroup-detail/modal/ScheduleForm'
 import { useBodyScrollLock } from '@/hooks'
+import { useUpdateStudySchedule } from '@/hooks/study-schedule'
 import {
   ScheduleFormModeType,
   type ScheduleFormValuesType,
   type StudyScheduleDetailType,
+  type UpdateStudyScheduleRequestType,
 } from '@/types'
 import { format, parseISO } from 'date-fns'
 
@@ -13,6 +15,7 @@ interface ScheduleEditModalProps {
   onClose: () => void
   onSave: (updated: StudyScheduleDetailType) => void
   schedule: StudyScheduleDetailType
+  groupId: number
 }
 
 export function ScheduleEditModal({
@@ -20,8 +23,11 @@ export function ScheduleEditModal({
   onClose,
   onSave,
   schedule,
+  groupId,
 }: ScheduleEditModalProps) {
   useBodyScrollLock(isOpen)
+
+  const { mutate } = useUpdateStudySchedule(groupId, schedule.id)
 
   const defaultValues: ScheduleFormValuesType = {
     title: schedule.title,
@@ -33,8 +39,7 @@ export function ScheduleEditModal({
   }
 
   const handleSubmit = (data: ScheduleFormValuesType) => {
-    const updated: StudyScheduleDetailType = {
-      ...schedule,
+    const payload: UpdateStudyScheduleRequestType = {
       title: data.title,
       objective: data.objective,
       session_date: data.date
@@ -42,9 +47,15 @@ export function ScheduleEditModal({
         : schedule.session_date,
       start_time: data.start_time,
       end_time: data.end_time,
-      participants: schedule.participants,
+      participants: data.participants,
     }
-    onSave(updated)
+
+    mutate(payload, {
+      onSuccess: (updated) => {
+        onSave(updated)
+        onClose()
+      },
+    })
   }
 
   return (

--- a/src/hooks/study-schedule/useDeleteStudySchedule.ts
+++ b/src/hooks/study-schedule/useDeleteStudySchedule.ts
@@ -4,15 +4,12 @@ import { useMutation, useQueryClient } from '@tanstack/react-query'
 import type { AxiosError } from 'axios'
 
 // 스터디 스케줄 삭제
-export const useDeleteStudySchedule = (
-  groupId: number | string,
-  scheduleId: number | string
-) => {
+export const useDeleteStudySchedule = (groupId: number | string) => {
   const queryClient = useQueryClient()
 
-  return useMutation<ScheduleSuccessResponseType, AxiosError>({
-    mutationFn: () => deleteStudySchedule(groupId, scheduleId),
-    onSuccess: () => {
+  return useMutation<ScheduleSuccessResponseType, AxiosError, number>({
+    mutationFn: (scheduleId) => deleteStudySchedule(groupId, scheduleId),
+    onSuccess: (_, scheduleId) => {
       // 삭제 후 스케줄 목록 새로고침
       queryClient.invalidateQueries({
         queryKey: ['study-schedules', groupId],

--- a/src/pages/StudyDetailPage.tsx
+++ b/src/pages/StudyDetailPage.tsx
@@ -6,8 +6,12 @@ import {
   StudyNoteList,
   StudyScheduleCalendar,
 } from '@/components/studygroup-detail'
+import { useParams } from 'react-router'
 
 export function StudyDetailPage() {
+  const { groupId } = useParams<{ groupId: string }>()
+  const numericGroupId = Number(groupId)
+
   return (
     <div className="flex flex-col gap-8 px-8 pb-20">
       {/* 상단 히어로 */}
@@ -16,7 +20,7 @@ export function StudyDetailPage() {
       {/* 좌측 메인 콘텐츠 */}
       <div className="flex flex-col gap-8 lg:flex-row">
         <div className="flex flex-1 flex-col gap-6">
-          <StudyScheduleCalendar />
+          <StudyScheduleCalendar groupId={numericGroupId} />
           <StudyNoteList />
         </div>
 


### PR DESCRIPTION
## ✨ PR 개요

스터디 스케줄 CRUD Query 기반으로 연동 및 캘린더/모달 흐름에 적용

## 📌 관련 이슈

Closes #98

## 🧩 작업 내용 (주요 변경사항)

- 스케줄 목록/수정/삭제 Query 훅 적용
- 상세 모달에서 수정/삭제 기능 연결
- 스케줄 삭제 시 목록·상세 캐시 갱신 처리

## 💬 리뷰 포인트

## 📸 스크린샷 (선택)

https://github.com/user-attachments/assets/4bc6434b-f2a1-4588-a278-18fd10f69f67


## 🧠 기타 참고사항

## ✅ PR 체크리스트

- [ ] 커밋 컨벤션 준수 (예: `feat: 로그인 구현`)
- [ ] 불필요한 console.log 제거
- [ ] 로컬에서 실행 확인 완료
