### PR TITLE
feat: 스터디 기록 TanStack Query 훅 UI 바인딩

### DIFF
--- a/src/components/studygroup-detail/FileUploader.tsx
+++ b/src/components/studygroup-detail/FileUploader.tsx
@@ -30,7 +30,7 @@ export function FileUploader() {
 
   return (
     <BaseUploader
-      accept={{ '*/*': [] }}
+      // accept={{ '*/*': [] }}
       maxSize={10 * 1024 * 1024}
       multiple
       onDrop={onDrop}

--- a/src/components/studygroup-detail/StudyNoteList.tsx
+++ b/src/components/studygroup-detail/StudyNoteList.tsx
@@ -1,4 +1,6 @@
 import { Button, Card } from '@/components/common'
+import { useStudyNotes } from '@/hooks/study-note'
+import { format } from 'date-fns'
 import { Pencil, UserRound } from 'lucide-react'
 import { useNavigate } from 'react-router'
 
@@ -8,6 +10,7 @@ interface StudyNoteListProps {
 
 export function StudyNoteList({ groupId }: StudyNoteListProps) {
   const navigate = useNavigate()
+  const { data } = useStudyNotes(groupId)
 
   const handleCreate = () => {
     navigate(`/study-groups/${groupId}/notes/create`)
@@ -16,6 +19,8 @@ export function StudyNoteList({ groupId }: StudyNoteListProps) {
   const handleNoteDetail = (noteId: number) => {
     navigate(`/study-groups/${groupId}/notes/${noteId}`)
   }
+
+  const notes = data?.results ?? []
 
   return (
     <section className="border-custom-gray-200 flex flex-col gap-4 rounded-xl border p-6">
@@ -30,35 +35,44 @@ export function StudyNoteList({ groupId }: StudyNoteListProps) {
           <span>작성하기</span>
         </Button>
       </div>
-      <ul>
-        <li>
-          <button
-            type="button"
-            // API 연동 시 note.id로 변경
-            onClick={() => handleNoteDetail(1)}
-            className="w-full"
-          >
-            <Card className="p-4">
-              <div className="flex justify-between pb-3">
-                <p className="text-custom-gray-900 text-lg">
-                  React Hooks 실습 정리
-                </p>
-                <span className="text-custom-gray-500 text-sm">
-                  2024. 02. 16. 오전 05:30
-                </span>
-              </div>
-              <div className="flex items-center gap-3 py-[2px]">
-                <span className="bg-primary-100 centralize h-8 w-8 rounded-full">
-                  <UserRound className="text-primary-600 h-5 w-5" />
-                </span>
-                <span className="text-custom-gray-700 text-sm font-medium">
-                  김개발
-                </span>
-              </div>
-            </Card>
-          </button>
-        </li>
-      </ul>
+
+      {notes.length > 0 ? (
+        <ul>
+          {notes.map((note) => (
+            <li key={note.id}>
+              <button
+                type="button"
+                onClick={() => handleNoteDetail(note.id)}
+                className="w-full"
+              >
+                <Card className="p-4">
+                  <div className="flex justify-between pb-3">
+                    <p className="text-custom-gray-900 text-lg">{note.title}</p>
+                    <span className="text-custom-gray-500 text-sm">
+                      {format(new Date(note.created_at), 'yyyy. MM. dd.')}
+                    </span>
+                  </div>
+                  <div className="flex items-center gap-3 py-[2px]">
+                    <span className="bg-primary-100 centralize h-8 w-8 rounded-full">
+                      <UserRound className="text-primary-600 h-5 w-5" />
+                    </span>
+                    <span className="text-custom-gray-700 text-sm font-medium">
+                      {note.author.nickname}
+                    </span>
+                  </div>
+                </Card>
+              </button>
+            </li>
+          ))}
+        </ul>
+      ) : (
+        <div className="centralize min-h-[194px] flex-col gap-2">
+          <p className="text-custom-gray-900 text-lg font-medium">
+            아직 작성된 스터디 기록이 없습니다.
+          </p>
+          <p className="text-custom-gray-600">첫 스터디 기록을 작성해보세요!</p>
+        </div>
+      )}
     </section>
   )
 }

--- a/src/components/studygroup-detail/StudyNoteList.tsx
+++ b/src/components/studygroup-detail/StudyNoteList.tsx
@@ -23,7 +23,7 @@ export function StudyNoteList({ groupId }: StudyNoteListProps) {
   const notes = data?.results ?? []
 
   return (
-    <section className="border-custom-gray-200 flex flex-col gap-4 rounded-xl border p-6">
+    <section className="border-custom-gray-200 flex flex-col rounded-xl border p-6">
       <div className="flex items-center justify-between pb-6">
         <p className="text-lg font-semibold">스터디 기록</p>
         <Button
@@ -37,7 +37,7 @@ export function StudyNoteList({ groupId }: StudyNoteListProps) {
       </div>
 
       {notes.length > 0 ? (
-        <ul>
+        <ul className="flex flex-col gap-4">
           {notes.map((note) => (
             <li key={note.id}>
               <button

--- a/src/hooks/study-note/useStudyNoteDetail.ts
+++ b/src/hooks/study-note/useStudyNoteDetail.ts
@@ -5,12 +5,11 @@ import { useQuery } from '@tanstack/react-query'
 // 스터디 노트 상세 조회
 export const useStudyNoteDetail = (
   groupId: number | string,
-  noteId: number | string,
-  enabled = true
+  noteId: number | string
 ) => {
   return useQuery<StudyNoteDetailType>({
     queryKey: ['study-note-detail', groupId, noteId],
     queryFn: () => getStudyNoteDetail(groupId, noteId),
-    enabled,
+    enabled: !!groupId && !!noteId,
   })
 }

--- a/src/hooks/study-note/useStudyNotes.ts
+++ b/src/hooks/study-note/useStudyNotes.ts
@@ -11,5 +11,6 @@ export const useStudyNotes = (
   return useQuery<StudyNoteListResponseType>({
     queryKey: ['study-notes', groupId, page, pageSize],
     queryFn: () => getStudyNotes(groupId, page, pageSize),
+    enabled: !!groupId,
   })
 }

--- a/src/mocks/handler.ts
+++ b/src/mocks/handler.ts
@@ -1,6 +1,7 @@
 import { MSW_BASE_URL } from '@/constants'
 import {
   chatHandlers,
+  noteHandlers,
   scheduleHandlers,
   studygroupHandler,
   userInformationHandler,
@@ -19,4 +20,5 @@ export const handlers = [
   ...reviewHandlers,
   ...studygroupHandler,
   ...scheduleHandlers,
+  ...noteHandlers,
 ]

--- a/src/pages/CreateStudyNotePage.tsx
+++ b/src/pages/CreateStudyNotePage.tsx
@@ -4,15 +4,27 @@ import { FileUploader } from '@/components/studygroup-detail'
 import { StudyNoteBreadcrumb } from '@/components/studygroup-note'
 import { useCreateStudyNote } from '@/hooks/study-note'
 import type { CreateStudyNoteRequestType } from '@/types'
-import { useState } from 'react'
+import { useEffect, useState } from 'react'
 import { useNavigate, useParams } from 'react-router'
+import { toast } from 'react-toastify'
 
 export function CreateStudyNotePage() {
   const { groupId } = useParams<{ groupId: string }>()
   const navigate = useNavigate()
   const [title, setTitle] = useState('')
 
-  const { mutate: createNote } = useCreateStudyNote(groupId!)
+  const isInvalidParams = !groupId
+
+  useEffect(() => {
+    if (isInvalidParams) {
+      toast.error('잘못된 접근입니다.')
+      navigate(-1)
+    }
+  }, [isInvalidParams, navigate])
+
+  const { mutate: createNote } = useCreateStudyNote(groupId ?? '')
+
+  if (isInvalidParams) return null
 
   const handleSubmit = () => {
     // content, files, images는 아직 MarkdownEditor, FileUploader와 연동되지 않음

--- a/src/pages/CreateStudyNotePage.tsx
+++ b/src/pages/CreateStudyNotePage.tsx
@@ -1,9 +1,40 @@
 import { Button, Input } from '@/components/common'
 import { MarkdownEditor } from '@/components/markdown'
-import { ImageUploader } from '@/components/studygroup'
+import { FileUploader } from '@/components/studygroup-detail'
 import { StudyNoteBreadcrumb } from '@/components/studygroup-note'
+import { useCreateStudyNote } from '@/hooks/study-note'
+import type { CreateStudyNoteRequestType } from '@/types'
+import { useState } from 'react'
+import { useNavigate, useParams } from 'react-router'
 
 export function CreateStudyNotePage() {
+  const { groupId } = useParams<{ groupId: string }>()
+  const navigate = useNavigate()
+  const [title, setTitle] = useState('')
+
+  const { mutate: createNote } = useCreateStudyNote(groupId!)
+
+  const handleSubmit = () => {
+    // content, files, images는 아직 MarkdownEditor, FileUploader와 연동되지 않음
+    // API 형태에 맞추기 위해 빈 값으로 payload 생성
+    const payload: CreateStudyNoteRequestType = {
+      title,
+      content: '',
+      files: [],
+      images: [],
+    }
+
+    createNote(payload, {
+      onSuccess: () => {
+        navigate(`/study-groups/${groupId}`)
+      },
+    })
+  }
+
+  const handleCancel = () => {
+    navigate(-1)
+  }
+
   return (
     <div className="flex flex-col p-8">
       <StudyNoteBreadcrumb mode="create" />
@@ -20,6 +51,8 @@ export function CreateStudyNotePage() {
         <Input
           label="제목"
           placeholder="스터디 기록의 제목을 입력하세요."
+          value={title}
+          onChange={(e) => setTitle(e.target.value)}
           required
         />
         <div>
@@ -33,13 +66,15 @@ export function CreateStudyNotePage() {
           <label className="text-custom-gray-700 text-sm font-medium">
             첨부 파일
           </label>
-          <ImageUploader />
+          <FileUploader />
         </div>
       </div>
 
       <div className="flex w-full justify-between gap-4 pt-6">
-        <Button variant="outline">취소</Button>
-        <Button variant="primary" className="px-8">
+        <Button variant="outline" onClick={handleCancel}>
+          취소
+        </Button>
+        <Button variant="primary" className="px-8" onClick={handleSubmit}>
           기록 저장
         </Button>
       </div>

--- a/src/pages/DetailStudyNotePage.tsx
+++ b/src/pages/DetailStudyNotePage.tsx
@@ -16,8 +16,7 @@ export function DetailStudyNotePage() {
   const { groupId, noteId } = useParams<{ groupId: string; noteId: string }>()
   const navigate = useNavigate()
 
-  const enabled = !!groupId && !!noteId
-  const { data } = useStudyNoteDetail(groupId ?? '', noteId ?? '', enabled)
+  const { data } = useStudyNoteDetail(groupId ?? '', noteId ?? '')
   const { mutate: deleteNote } = useDeleteStudyNote(groupId ?? '')
 
   const toggleSummary = () => setIsSummaryOpen((prev) => !prev)

--- a/src/pages/DetailStudyNotePage.tsx
+++ b/src/pages/DetailStudyNotePage.tsx
@@ -65,7 +65,7 @@ export function DetailStudyNotePage() {
             <span>{data.author.nickname}</span>
             <span>&bull;</span>
             <span>
-              작성일:
+              작성일:{' '}
               {format(new Date(data.created_at), 'yyyy. MM. dd. a h:mm')}
             </span>
           </p>

--- a/src/pages/DetailStudyNotePage.tsx
+++ b/src/pages/DetailStudyNotePage.tsx
@@ -5,34 +5,36 @@ import {
   StudyNoteBreadcrumb,
 } from '@/components/studygroup-note'
 import { StudyNoteToggle } from '@/components/studygroup-note/StudyNoteToggle'
+import { useDeleteStudyNote, useStudyNoteDetail } from '@/hooks/study-note'
+import { format } from 'date-fns'
 import { Bot, Paperclip, UserRound } from 'lucide-react'
 import { useState } from 'react'
 import { useNavigate, useParams } from 'react-router'
-
-// MSW 연동 후 mockFiles 제거 예정
-const mockFiles = [
-  {
-    id: 1,
-    file_name: 'hooks-practice.zip',
-    file_url: '#',
-  },
-  {
-    id: 2,
-    file_name: 'study-notes.pdf',
-    file_url: '#',
-  },
-]
 
 export function DetailStudyNotePage() {
   const [isSummaryOpen, setIsSummaryOpen] = useState(true)
   const { groupId, noteId } = useParams<{ groupId: string; noteId: string }>()
   const navigate = useNavigate()
 
+  const enabled = !!groupId && !!noteId
+  const { data } = useStudyNoteDetail(groupId ?? '', noteId ?? '', enabled)
+  const { mutate: deleteNote } = useDeleteStudyNote(groupId ?? '')
+
   const toggleSummary = () => setIsSummaryOpen((prev) => !prev)
 
   const handleEdit = () => {
     navigate(`/study-groups/${groupId}/notes/${noteId}/edit`)
   }
+
+  const handleDelete = () => {
+    deleteNote(Number(noteId), {
+      onSuccess: () => {
+        navigate(`/study-groups/${groupId}`)
+      },
+    })
+  }
+
+  if (!data) return null
 
   return (
     <div className="flex flex-col gap-6 p-8">
@@ -41,7 +43,7 @@ export function DetailStudyNotePage() {
         <header className="border-b-custom-gray-200 flex flex-col gap-4 border-b p-6">
           <div className="flex justify-between">
             <h1 className="text-custom-gray-900 text-2xl font-bold">
-              React Hooks 실습 정리
+              {data.title}
             </h1>
             <div className="flex gap-2">
               <Button variant="secondary" className="h-8" onClick={handleEdit}>
@@ -50,6 +52,7 @@ export function DetailStudyNotePage() {
               <Button
                 variant="danger"
                 className="text-danger-800 h-8 bg-[#FEE2E2]"
+                onClick={handleDelete}
               >
                 삭제하기
               </Button>
@@ -59,9 +62,12 @@ export function DetailStudyNotePage() {
             <span className="bg-primary-100 centralize h-8 w-8 rounded-full">
               <UserRound className="text-primary-600 h-5 w-5" />
             </span>
-            <span>김개발</span>
+            <span>{data.author.nickname}</span>
             <span>&bull;</span>
-            <span>작성일: 2024. 02. 16. 오전 05:30</span>
+            <span>
+              작성일:
+              {format(new Date(data.created_at), 'yyyy. MM. dd. a h:mm')}
+            </span>
           </p>
         </header>
 
@@ -78,24 +84,26 @@ export function DetailStudyNotePage() {
           </div>
           {isSummaryOpen && (
             <div className="text-custom-gray-900 bg-amber-50 p-4">
-              <p>AI 요약 내용</p>
+              <p>{data.ai_summary}</p>
             </div>
           )}
         </section>
 
         {/* 본문 */}
         <section className="border-b-custom-gray-200 border-b p-6">
-          <p>Markdown 본문 렌더</p>
+          <p>{data.content}</p>
         </section>
 
         {/* 첨부 파일 */}
         <section className="p-6">
           <h3 className="text-custom-gray-900 flex items-center gap-2 pb-4">
             <Paperclip className="h-5 w-5" />
-            <span className="text-lg font-normal">첨부 파일 (2개)</span>
+            <span className="text-lg font-normal">
+              첨부 파일 ({data.files.length}개)
+            </span>
           </h3>
           <ul className="grid grid-cols-2 gap-2">
-            {mockFiles.map((file) => (
+            {data.files.map((file) => (
               <StudyNoteAttachmentItem key={file.id} file={file} />
             ))}
           </ul>

--- a/src/pages/EditStudyNotePage.tsx
+++ b/src/pages/EditStudyNotePage.tsx
@@ -6,21 +6,23 @@ import { useStudyNoteDetail, useUpdateStudyNote } from '@/hooks/study-note'
 import type { UpdateStudyNoteRequestType } from '@/types'
 import { useEffect, useState } from 'react'
 import { useNavigate, useParams } from 'react-router'
+import { toast } from 'react-toastify'
 
 export function EditStudyNotePage() {
   const { groupId, noteId } = useParams<{ groupId: string; noteId: string }>()
   const navigate = useNavigate()
-
   const [title, setTitle] = useState('')
 
-  const hasParams = !!groupId && !!noteId
+  const isInvalidParams = !groupId || !noteId
 
-  const { data } = useStudyNoteDetail(
-    groupId ?? '',
-    noteId ?? '',
-    hasParams // 둘 다 있을 때만 API 호출
-  )
+  useEffect(() => {
+    if (isInvalidParams) {
+      toast.error('잘못된 접근입니다.')
+      navigate(-1)
+    }
+  }, [isInvalidParams, navigate])
 
+  const { data } = useStudyNoteDetail(groupId ?? '', noteId ?? '')
   const { mutate: updateNote } = useUpdateStudyNote(groupId ?? '', noteId ?? '')
 
   // 기존 데이터로 폼 초기화
@@ -29,6 +31,8 @@ export function EditStudyNotePage() {
       setTitle(data.title)
     }
   }, [data])
+
+  if (isInvalidParams) return null
 
   const handleSubmit = () => {
     // content, files는 아직 연동되지 않음

--- a/src/pages/EditStudyNotePage.tsx
+++ b/src/pages/EditStudyNotePage.tsx
@@ -2,16 +2,50 @@ import { Button, Input } from '@/components/common'
 import { MarkdownEditor } from '@/components/markdown'
 import { FileUploader } from '@/components/studygroup-detail'
 import { StudyNoteBreadcrumb } from '@/components/studygroup-note'
-import { useState } from 'react'
-
-const mockNote = {
-  title: 'React Hooks 실습 정리',
-  content: '기존 학습 내용 본문',
-  files: [{ id: 1, file_name: 'hooks-practice.zip', file_url: '#' }],
-}
+import { useStudyNoteDetail, useUpdateStudyNote } from '@/hooks/study-note'
+import type { UpdateStudyNoteRequestType } from '@/types'
+import { useEffect, useState } from 'react'
+import { useNavigate, useParams } from 'react-router'
 
 export function EditStudyNotePage() {
-  const [title, setTitle] = useState(mockNote.title)
+  const { groupId, noteId } = useParams<{ groupId: string; noteId: string }>()
+  const navigate = useNavigate()
+
+  const [title, setTitle] = useState('')
+
+  const hasParams = !!groupId && !!noteId
+
+  const { data } = useStudyNoteDetail(
+    groupId ?? '',
+    noteId ?? '',
+    hasParams // 둘 다 있을 때만 API 호출
+  )
+
+  const { mutate: updateNote } = useUpdateStudyNote(groupId ?? '', noteId ?? '')
+
+  // 기존 데이터로 폼 초기화
+  useEffect(() => {
+    if (data) {
+      setTitle(data.title)
+    }
+  }, [data])
+
+  const handleSubmit = () => {
+    // content, files는 아직 연동되지 않음
+    const payload: UpdateStudyNoteRequestType = {
+      title,
+    }
+
+    updateNote(payload, {
+      onSuccess: () => {
+        navigate(`/study-groups/${groupId}/notes/${noteId}`)
+      },
+    })
+  }
+
+  const handleCancel = () => {
+    navigate(-1)
+  }
 
   return (
     <div className="flex flex-col p-8">
@@ -49,8 +83,10 @@ export function EditStudyNotePage() {
       </div>
 
       <div className="flex w-full justify-between gap-4 pt-6">
-        <Button variant="outline">취소</Button>
-        <Button variant="primary" className="px-8">
+        <Button variant="outline" onClick={handleCancel}>
+          취소
+        </Button>
+        <Button variant="primary" className="px-8" onClick={handleSubmit}>
           수정 사항 저장
         </Button>
       </div>


### PR DESCRIPTION
## ✨ PR 개요

스터디 기록 생성/수정/상세 페이지에 TanStack Query 기반 훅 UI에 바인딩

## 📌 관련 이슈

Closes #117

## 🧩 작업 내용 (주요 변경사항)

- 스터디 기록 생성/수정/상세 페이지에 TanStack Query 훅 연동
- 삭제 / 수정 / 취소 버튼 동작 연결 

## 💬 리뷰 포인트

## 📸 스크린샷 (선택)
<img width="1514" height="673" alt="스크린샷 2025-12-09 오후 5 02 28" src="https://github.com/user-attachments/assets/152d0f61-c0f6-4549-aa37-9969aaadbaa5" />
<img width="1514" height="673" alt="스크린샷 2025-12-09 오후 5 02 24" src="https://github.com/user-attachments/assets/c40cae16-dda1-448a-ba61-bb693055385a" />

https://github.com/user-attachments/assets/5eb9ffa4-2722-4981-9481-4e4cb33530e0


## 🧠 기타 참고사항
1. 현재 PR에서는 TanStack Query 훅 연동까지의 범위를 다뤘으며,
아래 부분은 추후 별도 PR에서 보완될 예정입니다:
- MarkdownEditor / FileUploader 값이 상위 컴포넌트에서 제어되지 않아
생성, 수정 시 content/files 값이 반영되지 않는 문제

2. `Skipped '*/*' because it is not a valid MIME type`
MIME type 경고가 발생하여 FileUploader 내 `accept={{ '*/*': [] }}` 설정은 임시로 주석 처리했습니다.
- 해당 경고 관련해 GPT와 대화해본 결과, 모든 파일 형식을 지원하는 경우 `accept` prop을 제거하면 기본적으로 전체 파일이 허용된다고 합니다. 


## ✅ PR 체크리스트

- [ ] 커밋 컨벤션 준수 (예: `feat: 로그인 구현`)
- [ ] 불필요한 console.log 제거
- [ ] 로컬에서 실행 확인 완료
