### PR TITLE
refactor: 마크다운 에디터 상태 분리 및 구조 개선 (#120)

### DIFF
--- a/src/components/markdown/MarkdownEditor.tsx
+++ b/src/components/markdown/MarkdownEditor.tsx
@@ -7,8 +7,16 @@ import {
 } from '@/components/markdown'
 import { useMarkdownEditor } from '@/hooks'
 
-export function MarkdownEditor() {
-  const { value, setValue, textareaRef, insertMarkdown } = useMarkdownEditor()
+interface MarkdownEditorProps {
+  value: string
+  onChange: (v: string) => void
+}
+
+export function MarkdownEditor({
+  value,
+  onChange: setValue,
+}: MarkdownEditorProps) {
+  const { textareaRef, insertMarkdown } = useMarkdownEditor({ value, setValue })
   const [mode, setMode] = useState<'write' | 'preview'>('write')
 
   return (

--- a/src/hooks/useMarkdownEditor.ts
+++ b/src/hooks/useMarkdownEditor.ts
@@ -1,7 +1,11 @@
-import { useCallback, useRef, useState } from 'react'
+import { useCallback, useRef } from 'react'
 
-export function useMarkdownEditor() {
-  const [value, setValue] = useState('')
+interface UseMarkdownEditorProps {
+  value: string
+  setValue: (v: string) => void
+}
+
+export function useMarkdownEditor({ value, setValue }: UseMarkdownEditorProps) {
   const textareaRef = useRef<HTMLTextAreaElement | null>(null)
 
   const insertMarkdown = useCallback(
@@ -25,12 +29,10 @@ export function useMarkdownEditor() {
         textareaRef.current.selectionEnd = next
       })
     },
-    [value]
+    [value, setValue]
   )
 
   return {
-    value,
-    setValue,
     textareaRef,
     insertMarkdown,
   }


### PR DESCRIPTION
## ✨ PR 개요

<!-- 어떤 작업을 했는지 간략히 요약 -->
마크다운 에디터 상태 분리 및 구조 개선 

## 📌 관련 이슈

<!-- Closes #이슈번호 -->

Closes #120 

## 🧩 작업 내용 (주요 변경사항)
- `useMarkdownEditor` 훅에서 내부 상태 제거
- `MarkdownEditor` 컴포넌트가 상태를 직접 관리하도록 구조 변경
- 외부 폼/페이지에서 마크다운 값 완전 제어 가능

## 💬 리뷰 포인트

<!-- 특히 봐줬으면 하는 부분 (예: 상태관리 로직 구조 괜찮은지 봐주세요) -->

## 📸 스크린샷 (선택)

<!-- UI 변경이 있다면 캡처나 GIF 첨부 -->

## 🧠 기타 참고사항

<!-- 추가로 알아야 할 점 (예: 임시로 넣은 더미 데이터 있음) -->

## ✅ PR 체크리스트

- [x] 커밋 컨벤션 준수 (예: `feat: 로그인 구현`)
- [x] 로컬에서 실행 확인 완료
