### PR TITLE
Feature: 라우트 변경 시 스크롤 Top으로 이동하는 훅 구현

### DIFF
--- a/src/components/layout/Layout.tsx
+++ b/src/components/layout/Layout.tsx
@@ -1,10 +1,13 @@
 import { ChatWidget } from '@/components/chat'
 import { Footer, Header } from '@/components/layout'
+import { useScrollToTopOnRouteChange } from '@/hooks/common/useScrollToTopOnRouteChange'
 import { LoginStateStore } from '@/store'
 import { useState } from 'react'
 import { Outlet } from 'react-router'
 
 export function Layout() {
+  useScrollToTopOnRouteChange()
+
   const [isSideBarOpen, setIsSideBarOpen] = useState(false)
   const loginState = LoginStateStore((state) => state.loginState)
   const isLoggedIn = loginState === 'USER'

--- a/src/hooks/common/useScrollToTopOnRouteChange.ts
+++ b/src/hooks/common/useScrollToTopOnRouteChange.ts
@@ -1,0 +1,14 @@
+import { useEffect } from 'react'
+import { useLocation } from 'react-router'
+
+export function useScrollToTopOnRouteChange() {
+  const { pathname } = useLocation()
+
+  useEffect(() => {
+    window.scrollTo({
+      top: 0,
+      left: 0,
+      behavior: 'auto',
+    })
+  }, [pathname])
+}


### PR DESCRIPTION
## ✨ PR 개요

라우트 변경 시 스크롤 Top으로 이동하는 훅 구현

## 📌 관련 이슈

Closes #128

## 🧩 작업 내용 (주요 변경사항)

- 라우트 변경 시 스크롤 Top으로 이동하는 훅 구현
- `Layout`에 적용

## 💬 리뷰 포인트


## 📸 스크린샷 (선택)

### Before
https://github.com/user-attachments/assets/9353e443-e919-4016-8e66-18319a60f283

### After
https://github.com/user-attachments/assets/7e2b4e7e-1c55-460e-96cd-86738a12e001

## 🧠 기타 참고사항


## ✅ PR 체크리스트

- [ ] 커밋 컨벤션 준수 (예: `feat: 로그인 구현`)
- [ ] 불필요한 console.log 제거
- [ ] 로컬에서 실행 확인 완료
