### PR TITLE
Feature: 스터디 그룹 상세 페이지 TanStack Query Hook

### DIFF
--- a/src/api/schedule.ts
+++ b/src/api/schedule.ts
@@ -15,7 +15,7 @@ export const createStudySchedule = async (
   body: CreateStudyScheduleRequestType
 ) => {
   const { data } = await axiosInstance.post<ScheduleSuccessResponseType>(
-    API_PATHS.STUDYGROUP.SCHEDULES(groupId),
+    API_PATHS.SCHEDULE.LIST(groupId),
     body
   )
   return data
@@ -25,7 +25,7 @@ export const createStudySchedule = async (
 // GET /api/v1/study-groups/{group_id}/schedules
 export const getStudySchedules = async (groupId: number | string) => {
   const { data } = await axiosInstance.get<StudyScheduleListItemType[]>(
-    API_PATHS.STUDYGROUP.SCHEDULES(groupId)
+    API_PATHS.SCHEDULE.LIST(groupId)
   )
   return data
 }
@@ -37,7 +37,7 @@ export const getStudyScheduleDetail = async (
   scheduleId: number | string
 ) => {
   const { data } = await axiosInstance.get<StudyScheduleDetailType>(
-    API_PATHS.STUDYGROUP.SCHEDULE_DETAIL(groupId, scheduleId)
+    API_PATHS.SCHEDULE.DETAIL(groupId, scheduleId)
   )
   return data
 }
@@ -50,7 +50,7 @@ export const updateStudySchedule = async (
   body: UpdateStudyScheduleRequestType
 ) => {
   const { data } = await axiosInstance.patch<StudyScheduleDetailType>(
-    API_PATHS.STUDYGROUP.SCHEDULE_DETAIL(groupId, scheduleId),
+    API_PATHS.SCHEDULE.DETAIL(groupId, scheduleId),
     body
   )
   return data
@@ -63,7 +63,7 @@ export const deleteStudySchedule = async (
   scheduleId: number | string
 ) => {
   const { data } = await axiosInstance.delete<ScheduleSuccessResponseType>(
-    API_PATHS.STUDYGROUP.SCHEDULE_DETAIL(groupId, scheduleId)
+    API_PATHS.SCHEDULE.DETAIL(groupId, scheduleId)
   )
   return data
 }

--- a/src/api/studygroup.ts
+++ b/src/api/studygroup.ts
@@ -1,0 +1,66 @@
+import { axiosInstance } from '@/api/axios'
+import { API_PATHS } from '@/constants'
+import type {
+  StudyGroupDetailType,
+  StudyGroupSuccessResponseType,
+  UpdateStudyGroupRequestType,
+} from '@/types'
+
+// 스터디 그룹 상세 조회
+export const getStudyGroupDetail = async (groupId: number | string) => {
+  const { data } = await axiosInstance.get<StudyGroupDetailType>(
+    API_PATHS.STUDYGROUP.DETAIL(groupId)
+  )
+  return data
+}
+
+// 스터디 그룹 수정
+export const updateStudyGroup = async (
+  groupId: number | string,
+  body: UpdateStudyGroupRequestType
+) => {
+  const { data } = await axiosInstance.patch<StudyGroupDetailType>(
+    API_PATHS.STUDYGROUP.DETAIL(groupId),
+    body
+  )
+  return data
+}
+
+// 스터디 그룹 삭제
+export const deleteStudyGroup = async (groupId: number | string) => {
+  const { data } = await axiosInstance.delete<StudyGroupSuccessResponseType>(
+    API_PATHS.STUDYGROUP.DETAIL(groupId)
+  )
+  return data
+}
+
+// 스터디 그룹 나가기
+export const leaveStudyGroup = async (groupId: number | string) => {
+  const { data } = await axiosInstance.delete<StudyGroupSuccessResponseType>(
+    API_PATHS.STUDYGROUP.LEAVE(groupId)
+  )
+  return data
+}
+
+// 리더 위임
+export const delegateStudyGroupLeader = async (
+  groupId: number | string,
+  targetMemberId: number
+) => {
+  const { data } = await axiosInstance.post<StudyGroupSuccessResponseType>(
+    API_PATHS.STUDYGROUP.DELEGATE_LEADER(groupId),
+    { target_member_id: targetMemberId }
+  )
+  return data
+}
+
+// 멤버 추방
+export const kickStudyGroupMember = async (
+  groupId: number | string,
+  memberId: number | string
+) => {
+  const { data } = await axiosInstance.delete<StudyGroupSuccessResponseType>(
+    API_PATHS.STUDYGROUP.KICK_MEMBER(groupId, memberId)
+  )
+  return data
+}

--- a/src/constants/api.ts
+++ b/src/constants/api.ts
@@ -22,12 +22,19 @@ export const API_PATHS = {
   },
   STUDYGROUP: {
     LIST: `/api/v1/study-groups`,
-    SCHEDULES: (group_id: number | string) =>
+    DETAIL: (groupId: number | string) => `/api/v1/study-groups/${groupId}`,
+    DELEGATE_LEADER: (groupId: number | string) =>
+      `/api/v1/study-groups/${groupId}/delegate-leader`,
+    LEAVE: (groupId: number | string) =>
+      `/api/v1/study-groups/${groupId}/members/me`,
+    KICK_MEMBER: (groupId: number | string, memberId: number | string) =>
+      `/api/v1/study-groups/${groupId}/members/${memberId}`,
+  },
+  SCHEDULE: {
+    LIST: (group_id: number | string) =>
       `/api/v1/study-groups/${group_id}/schedules`,
-    SCHEDULE_DETAIL: (
-      group_id: number | string,
-      schedule_id: number | string
-    ) => `/api/v1/study-groups/${group_id}/schedules/${schedule_id}`,
+    DETAIL: (group_id: number | string, schedule_id: number | string) =>
+      `/api/v1/study-groups/${group_id}/schedules/${schedule_id}`,
   },
   STUDYNOTE: {
     LIST: (groupId: number | string) => `/api/v1/study-groups/${groupId}/notes`,

--- a/src/hooks/study-group/index.ts
+++ b/src/hooks/study-group/index.ts
@@ -1,0 +1,6 @@
+export * from './useDelegateStudyGroupLeader'
+export * from './useDeleteStudyGroup'
+export * from './useKickStudyGroupMember'
+export * from './useLeaveStudyGroup'
+export * from './useStudyGroupDetail'
+export * from './useUpdateStudyGroup'

--- a/src/hooks/study-group/useDelegateStudyGroupLeader.ts
+++ b/src/hooks/study-group/useDelegateStudyGroupLeader.ts
@@ -1,0 +1,19 @@
+import { delegateStudyGroupLeader } from '@/api/studygroup'
+import type { StudyGroupSuccessResponseType } from '@/types'
+import { useMutation, useQueryClient } from '@tanstack/react-query'
+import type { AxiosError } from 'axios'
+
+// 리더 위임
+export const useDelegateStudyGroupLeader = (groupId: number | string) => {
+  const queryClient = useQueryClient()
+
+  return useMutation<StudyGroupSuccessResponseType, AxiosError, number>({
+    mutationFn: (targetMemberId) =>
+      delegateStudyGroupLeader(groupId, targetMemberId),
+    onSuccess: () => {
+      queryClient.invalidateQueries({
+        queryKey: ['study-group-detail', groupId],
+      })
+    },
+  })
+}

--- a/src/hooks/study-group/useDeleteStudyGroup.ts
+++ b/src/hooks/study-group/useDeleteStudyGroup.ts
@@ -1,0 +1,23 @@
+import { deleteStudyGroup } from '@/api/studygroup'
+import type { StudyGroupSuccessResponseType } from '@/types'
+import { useMutation, useQueryClient } from '@tanstack/react-query'
+import type { AxiosError } from 'axios'
+
+// 스터디 그룹 삭제
+export const useDeleteStudyGroup = () => {
+  const queryClient = useQueryClient()
+
+  return useMutation<
+    StudyGroupSuccessResponseType,
+    AxiosError,
+    string | number
+  >({
+    mutationFn: (groupId) => deleteStudyGroup(groupId),
+    onSuccess: (_, groupId) => {
+      // 삭제된 그룹 캐시 제거
+      queryClient.removeQueries({ queryKey: ['study-group-detail', groupId] })
+      // 목록 갱신
+      queryClient.invalidateQueries({ queryKey: ['study-groups'] })
+    },
+  })
+}

--- a/src/hooks/study-group/useKickStudyGroupMember.ts
+++ b/src/hooks/study-group/useKickStudyGroupMember.ts
@@ -1,0 +1,22 @@
+import { kickStudyGroupMember } from '@/api/studygroup'
+import type { StudyGroupSuccessResponseType } from '@/types'
+import { useMutation, useQueryClient } from '@tanstack/react-query'
+import type { AxiosError } from 'axios'
+
+// 멤버 추방
+export const useKickStudyGroupMember = (groupId: string | number) => {
+  const queryClient = useQueryClient()
+
+  return useMutation<
+    StudyGroupSuccessResponseType,
+    AxiosError,
+    string | number
+  >({
+    mutationFn: (memberId) => kickStudyGroupMember(groupId, memberId),
+    onSuccess: () => {
+      queryClient.invalidateQueries({
+        queryKey: ['study-group-detail', groupId],
+      })
+    },
+  })
+}

--- a/src/hooks/study-group/useLeaveStudyGroup.ts
+++ b/src/hooks/study-group/useLeaveStudyGroup.ts
@@ -1,0 +1,27 @@
+import { leaveStudyGroup } from '@/api/studygroup'
+import type { StudyGroupSuccessResponseType } from '@/types'
+import { useMutation, useQueryClient } from '@tanstack/react-query'
+import type { AxiosError } from 'axios'
+
+// 스터디 그룹 나가기
+export const useLeaveStudyGroup = () => {
+  const queryClient = useQueryClient()
+
+  return useMutation<
+    StudyGroupSuccessResponseType,
+    AxiosError,
+    string | number
+  >({
+    mutationFn: (groupId) => leaveStudyGroup(groupId),
+    onSuccess: (_, groupId) => {
+      // 해당 그룹 상세 캐시 무효화
+      queryClient.invalidateQueries({
+        queryKey: ['study-group-detail', groupId],
+      })
+      // 목록 갱신
+      queryClient.invalidateQueries({
+        queryKey: ['study-groups'],
+      })
+    },
+  })
+}

--- a/src/hooks/study-group/useStudyGroupDetail.ts
+++ b/src/hooks/study-group/useStudyGroupDetail.ts
@@ -1,0 +1,12 @@
+import { getStudyGroupDetail } from '@/api/studygroup'
+import type { StudyGroupDetailType } from '@/types'
+import { useQuery } from '@tanstack/react-query'
+
+// 스터디 그룹 상세 조회
+export const useStudyGroupDetail = (groupId: string | number) => {
+  return useQuery<StudyGroupDetailType>({
+    queryKey: ['study-group-detail', groupId],
+    queryFn: () => getStudyGroupDetail(groupId),
+    enabled: !!groupId,
+  })
+}

--- a/src/hooks/study-group/useUpdateStudyGroup.ts
+++ b/src/hooks/study-group/useUpdateStudyGroup.ts
@@ -1,0 +1,27 @@
+import { updateStudyGroup } from '@/api/studygroup'
+import type { StudyGroupDetailType, UpdateStudyGroupRequestType } from '@/types'
+import { useMutation, useQueryClient } from '@tanstack/react-query'
+import type { AxiosError } from 'axios'
+
+// 스터디 그룹 수정
+export const useUpdateStudyGroup = (groupId: string | number) => {
+  const queryClient = useQueryClient()
+
+  return useMutation<
+    StudyGroupDetailType,
+    AxiosError,
+    UpdateStudyGroupRequestType
+  >({
+    mutationFn: (body) => updateStudyGroup(groupId, body),
+    onSuccess: () => {
+      // 상세 데이터 갱신
+      queryClient.invalidateQueries({
+        queryKey: ['study-group-detail', groupId],
+      })
+      // 목록 갱신
+      queryClient.invalidateQueries({
+        queryKey: ['study-groups'],
+      })
+    },
+  })
+}

--- a/src/types/studygroup-detail.ts
+++ b/src/types/studygroup-detail.ts
@@ -1,5 +1,4 @@
-// api/v1/study-groups/{group_id}
-// 스터디 그룹 상세 조회 응답 타입
+// api/v1/study-groups/{group_id} 관련 타입들
 
 // 스터디 그룹 진행 상태
 export type StudyGroupStatus = 'PENDING' | 'ONGOING' | 'ENDED'
@@ -34,4 +33,25 @@ export interface StudyGroupDetailType {
   status: StudyGroupStatus
   lectures: StudyGroupLectureType[]
   members: StudyGroupMemberType[]
+}
+
+// 스터디 그룹 수정 요청
+export interface UpdateStudyGroupRequestType {
+  name?: string
+  introduction?: string
+  start_at?: string
+  end_at?: string
+  max_headcount?: number
+  profile_img_url?: string
+  lectures?: number[]
+}
+
+// 리더 위임 요청
+export interface DelegateLeaderRequestType {
+  target_member_id: number
+}
+
+// 공통 성공 응답
+export interface StudyGroupSuccessResponseType {
+  detail: string
 }


### PR DESCRIPTION
## ✨ PR 개요

스터디 그룹 상세 페이지 TanStack Query Hook 구현

## 📌 관련 이슈

Closes #132

## 🧩 작업 내용 (주요 변경사항)

- 스터디 그룹 상세 관련 타입 정의
- 스터디 그룹 상세 API 함수 구현
- Tanstack Query 훅 구현

## 💬 리뷰 포인트

## 📸 스크린샷 (선택)

## 🧠 기타 참고사항

- 상세 페이지 UI와의 실제 데이터 연동은 다음 PR에서 진행 예정입니다. 
(MSW 핸들러 구현 이후 연결할 예정)

## ✅ PR 체크리스트

- [ ] 커밋 컨벤션 준수 (예: `feat: 로그인 구현`)
- [ ] 불필요한 console.log 제거
- [ ] 로컬에서 실행 확인 완료
