### PR TITLE
Feature: 스터디 그룹 상세 페이지 MSW handler

### DIFF
--- a/src/mocks/handler.ts
+++ b/src/mocks/handler.ts
@@ -8,6 +8,7 @@ import {
   studygroupHandler,
   userInformationHandler,
 } from '@/mocks/handlers'
+import { studygroupDetailHandlers } from '@/mocks/handlers/studygroup-details-handler'
 import { http, HttpResponse } from 'msw'
 
 const getTestMSW = http.get(`${MSW_BASE_URL}/get-test`, () => {
@@ -22,5 +23,6 @@ export const handlers = [
   ...reviewHandlers,
   ...scheduleHandlers,
   ...studygroupHandler,
+  ...studygroupDetailHandlers,
   ...userInformationHandler,
 ]

--- a/src/mocks/handlers/studygroup-details-handler.ts
+++ b/src/mocks/handlers/studygroup-details-handler.ts
@@ -1,0 +1,237 @@
+import { mockScheduleParticipants, mockStudyList } from '@/mocks/data'
+import type {
+  DelegateLeaderRequestType,
+  StudyGroupDetailType,
+  UpdateStudyGroupRequestType,
+  UpdateStudyGroupResponseType,
+} from '@/types'
+import { http, HttpResponse } from 'msw'
+
+// 상세 조회
+export const getStudyGroupDetailHandler = http.get(
+  '/api/v1/study-groups/:groupId',
+  ({ params }) => {
+    const groupId = Number(params.groupId)
+    const studyGroup = mockStudyList.find(
+      (studyGroupItem) => studyGroupItem.id === groupId
+    )
+
+    if (!studyGroup) {
+      return HttpResponse.json(
+        { error_detail: '스터디 그룹을 찾을 수 없습니다.' },
+        { status: 404 }
+      )
+    }
+
+    const detailStudyGroup: StudyGroupDetailType = {
+      id: studyGroup.id,
+      name: studyGroup.name,
+      introduction: `${studyGroup.name}입니다. 함께 성장해유~ ^00^!`,
+      start_at: studyGroup.start_at,
+      end_at: studyGroup.end_at,
+      max_headcount: studyGroup.max_headcount,
+      current_headcount: studyGroup.current_headcount,
+      profile_img_url: studyGroup.profile_img_url,
+      status: studyGroup.status,
+      lectures: studyGroup.lectures.map((lecture) => ({
+        ...lecture,
+        thumbnail_img_url:
+          'https://cdn.inflearn.com/public/files/courses/328340/cover/01jx9xv8sprqfcjdkhy723nw9y?f=avif&w=420',
+        url_link: 'https://www.inflearn.com',
+      })),
+      members: mockScheduleParticipants,
+    }
+
+    return HttpResponse.json(detailStudyGroup, { status: 200 })
+  }
+)
+
+// 수정
+export const updateStudyGroupHandler = http.patch(
+  '/api/v1/study-groups/:groupId',
+  async ({ params, request }) => {
+    const groupId = Number(params.groupId)
+    const body = (await request.json()) as UpdateStudyGroupRequestType
+
+    const studyGroupIndex = mockStudyList.findIndex(
+      (studyGroupItem) => studyGroupItem.id === groupId
+    )
+
+    if (studyGroupIndex === -1) {
+      return HttpResponse.json(
+        { error_detail: '스터디 그룹을 찾을 수 없습니다.' },
+        { status: 404 }
+      )
+    }
+
+    const existingStudyGroup = mockStudyList[studyGroupIndex]
+
+    // 기존 데이터 업데이트
+    const updatedStudyGroup = {
+      ...existingStudyGroup,
+      name: body.name ?? existingStudyGroup.name,
+      start_at: body.start_at ?? existingStudyGroup.start_at,
+      end_at: body.end_at ?? existingStudyGroup.end_at,
+      max_headcount: body.max_headcount ?? existingStudyGroup.max_headcount,
+      profile_img_url:
+        body.profile_img_url ?? existingStudyGroup.profile_img_url,
+    }
+
+    mockStudyList[studyGroupIndex] = updatedStudyGroup
+
+    // 상세 응답 형태로 반환
+    const updateResponse: UpdateStudyGroupResponseType = {
+      id: updatedStudyGroup.id,
+      name: updatedStudyGroup.name,
+      introduction:
+        body.introduction ??
+        `${updatedStudyGroup.name}입니다. 함께 성장해유~ ^00^!`,
+      start_at: updatedStudyGroup.start_at,
+      end_at: updatedStudyGroup.end_at,
+      max_headcount: updatedStudyGroup.max_headcount,
+      profile_img_url: updatedStudyGroup.profile_img_url,
+      status: updatedStudyGroup.status,
+      lectures: updatedStudyGroup.lectures.map((lecture) => ({
+        ...lecture,
+        thumbnail_img_url:
+          'https://cdn.inflearn.com/public/files/courses/328340/cover/01jx9xv8sprqfcjdkhy723nw9y?f=avif&w=420',
+        url_link: 'https://www.inflearn.com',
+      })),
+    }
+
+    return HttpResponse.json(updateResponse, { status: 200 })
+  }
+)
+
+// 삭제
+export const deleteStudyGroupHandler = http.delete(
+  '/api/v1/study-groups/:groupId',
+  ({ params }) => {
+    const groupId = Number(params.groupId)
+    const studyGroupIndex = mockStudyList.findIndex(
+      (studyGroupItem) => studyGroupItem.id === groupId
+    )
+
+    if (studyGroupIndex === -1) {
+      return HttpResponse.json(
+        { error_detail: '스터디 그룹을 찾을 수 없습니다.' },
+        { status: 404 }
+      )
+    }
+
+    mockStudyList.splice(studyGroupIndex, 1)
+
+    return HttpResponse.json(
+      { detail: '스터디 그룹이 삭제되었습니다.' },
+      { status: 200 }
+    )
+  }
+)
+
+// 리더 위임
+export const delegateLeaderHandler = http.post(
+  '/api/v1/study-groups/:groupId/delegate-leader',
+  async ({ params, request }) => {
+    const groupId = Number(params.groupId)
+    const body = (await request.json()) as DelegateLeaderRequestType
+
+    const studyGroup = mockStudyList.find(
+      (studyGroupItem) => studyGroupItem.id === groupId
+    )
+
+    if (!studyGroup) {
+      return HttpResponse.json(
+        { error_detail: '스터디 그룹을 찾을 수 없습니다.' },
+        { status: 404 }
+      )
+    }
+
+    if (!body.target_member_id) {
+      return HttpResponse.json(
+        { error_detail: '해당 멤버를 찾을 수 없습니다.' },
+        { status: 404 }
+      )
+    }
+
+    return HttpResponse.json(
+      { detail: '리더 권한이 위임되었습니다.' },
+      { status: 200 }
+    )
+  }
+)
+
+// 나가기
+export const leaveStudyGroupHandler = http.delete(
+  '/api/v1/study-groups/:groupId/members/me',
+  ({ params }) => {
+    const groupId = Number(params.groupId)
+    const studyGroup = mockStudyList.find(
+      (studyGroupItem) => studyGroupItem.id === groupId
+    )
+
+    if (!studyGroup) {
+      return HttpResponse.json(
+        { error_detail: '스터디 그룹을 찾을 수 없습니다.' },
+        { status: 404 }
+      )
+    }
+
+    // 실제 API는 로그인 유저 기준으로 판단, 핸들러에서는 목록 mock의 is_leader 활용
+    if (studyGroup.is_leader) {
+      return HttpResponse.json(
+        {
+          error_detail:
+            '리더는 다른 멤버에게 리더 권한을 위임하고 나가야 합니다.',
+        },
+        { status: 400 }
+      )
+    }
+
+    return HttpResponse.json(
+      { detail: '스터디 그룹에서 나가기에 성공하였습니다.' },
+      { status: 200 }
+    )
+  }
+)
+
+// 멤버 추방
+export const kickMemberHandler = http.delete(
+  '/api/v1/study-groups/:groupId/members/:memberId',
+  ({ params }) => {
+    const groupId = Number(params.groupId)
+    const memberId = Number(params.memberId)
+
+    const studyGroup = mockStudyList.find(
+      (studyGroupItem) => studyGroupItem.id === groupId
+    )
+
+    if (!studyGroup) {
+      return HttpResponse.json(
+        { error_detail: '스터디 그룹을 찾을 수 없습니다.' },
+        { status: 404 }
+      )
+    }
+
+    const member = mockScheduleParticipants.find((m) => m.id === memberId)
+    if (!member) {
+      return HttpResponse.json(
+        { error_detail: '해당 멤버를 찾을 수 없습니다.' },
+        { status: 404 }
+      )
+    }
+
+    return HttpResponse.json(
+      { detail: '스터디 그룹에서 멤버를 추방하는데 성공했습니다.' },
+      { status: 200 }
+    )
+  }
+)
+
+export const studygroupDetailHandlers = [
+  getStudyGroupDetailHandler,
+  updateStudyGroupHandler,
+  deleteStudyGroupHandler,
+  delegateLeaderHandler,
+  leaveStudyGroupHandler,
+  kickMemberHandler,
+]

--- a/src/mocks/handlers/studygroup-handler.ts
+++ b/src/mocks/handlers/studygroup-handler.ts
@@ -1,66 +1,9 @@
 import { http, HttpResponse } from 'msw'
 import { mockStudyList } from '@/mocks/data/studygroup'
 import { API_PATHS } from '@/constants'
-import type { StudyGroupDetailType } from '@/types'
 
 export const studygroupHandler = [
   http.get(API_PATHS.STUDYGROUP.LIST, () => {
     return HttpResponse.json(mockStudyList)
   }),
 ]
-
-// 상세 조회
-export const getStudyGroupDetailHandler = http.get(
-  '/api/v1/study-groups/:groupId',
-  ({ params }) => {
-    const groupId = Number(params.groupId)
-    const group = mockStudyList.find((group) => group.id === groupId)
-
-    if (!group) {
-      return HttpResponse.json(
-        { error_detail: '스터디 그룹을 찾을 수 없습니다.' },
-        { status: 404 }
-      )
-    }
-
-    const detailStudyGroup: StudyGroupDetailType = {
-      id: group.id,
-      name: group.name,
-      introduction: `${group.name}입니다. 함께 성장해요!`,
-      start_at: group.start_at,
-      end_at: group.end_at,
-      max_headcount: group.max_headcount,
-      current_headcount: group.current_headcount,
-      profile_img_url: group.profile_img_url,
-      status: group.status,
-      lectures: group.lectures.map((lecture) => ({
-        ...lecture,
-        thumbnail_img_url:
-          'https://cdn.inflearn.com/public/files/courses/328340/cover/01jx9xv8sprqfcjdkhy723nw9y?f=avif&w=420',
-        url_link: 'https://www.inflearn.com',
-      })),
-      members: [
-        {
-          id: 1,
-          nickname: '김스터디',
-          is_leader: true,
-          profile_img_url: 'https://randomuser.me/api/portraits/lego/1.jpg',
-        },
-        {
-          id: 2,
-          nickname: '최자바',
-          is_leader: false,
-          profile_img_url: 'https://randomuser.me/api/portraits/lego/2.jpg',
-        },
-        {
-          id: 3,
-          nickname: '이프론트',
-          is_leader: false,
-          profile_img_url: 'https://randomuser.me/api/portraits/lego/3.jpg',
-        },
-      ],
-    }
-
-    return HttpResponse.json(detailStudyGroup, { status: 200 })
-  }
-)

--- a/src/mocks/handlers/studygroup-handler.ts
+++ b/src/mocks/handlers/studygroup-handler.ts
@@ -1,9 +1,66 @@
 import { http, HttpResponse } from 'msw'
 import { mockStudyList } from '@/mocks/data/studygroup'
 import { API_PATHS } from '@/constants'
+import type { StudyGroupDetailType } from '@/types'
 
 export const studygroupHandler = [
   http.get(API_PATHS.STUDYGROUP.LIST, () => {
     return HttpResponse.json(mockStudyList)
   }),
 ]
+
+// 상세 조회
+export const getStudyGroupDetailHandler = http.get(
+  '/api/v1/study-groups/:groupId',
+  ({ params }) => {
+    const groupId = Number(params.groupId)
+    const group = mockStudyList.find((group) => group.id === groupId)
+
+    if (!group) {
+      return HttpResponse.json(
+        { error_detail: '스터디 그룹을 찾을 수 없습니다.' },
+        { status: 404 }
+      )
+    }
+
+    const detailStudyGroup: StudyGroupDetailType = {
+      id: group.id,
+      name: group.name,
+      introduction: `${group.name}입니다. 함께 성장해요!`,
+      start_at: group.start_at,
+      end_at: group.end_at,
+      max_headcount: group.max_headcount,
+      current_headcount: group.current_headcount,
+      profile_img_url: group.profile_img_url,
+      status: group.status,
+      lectures: group.lectures.map((lecture) => ({
+        ...lecture,
+        thumbnail_img_url:
+          'https://cdn.inflearn.com/public/files/courses/328340/cover/01jx9xv8sprqfcjdkhy723nw9y?f=avif&w=420',
+        url_link: 'https://www.inflearn.com',
+      })),
+      members: [
+        {
+          id: 1,
+          nickname: '김스터디',
+          is_leader: true,
+          profile_img_url: 'https://randomuser.me/api/portraits/lego/1.jpg',
+        },
+        {
+          id: 2,
+          nickname: '최자바',
+          is_leader: false,
+          profile_img_url: 'https://randomuser.me/api/portraits/lego/2.jpg',
+        },
+        {
+          id: 3,
+          nickname: '이프론트',
+          is_leader: false,
+          profile_img_url: 'https://randomuser.me/api/portraits/lego/3.jpg',
+        },
+      ],
+    }
+
+    return HttpResponse.json(detailStudyGroup, { status: 200 })
+  }
+)

--- a/src/types/studygroup-detail.ts
+++ b/src/types/studygroup-detail.ts
@@ -46,6 +46,12 @@ export interface UpdateStudyGroupRequestType {
   lectures?: number[]
 }
 
+// 스터디 그룹 수정 응답
+export type UpdateStudyGroupResponseType = Omit<
+  StudyGroupDetailType,
+  'current_headcount' | 'members'
+>
+
 // 리더 위임 요청
 export interface DelegateLeaderRequestType {
   target_member_id: number

--- a/src/types/studygroup-detail.ts
+++ b/src/types/studygroup-detail.ts
@@ -17,7 +17,7 @@ export interface StudyGroupMemberType {
   id: number
   nickname: string
   is_leader: boolean
-  profile_img_url: string
+  profile_img_url: string | null
 }
 
 // 스터디 그룹 상세 조회 응답
@@ -29,7 +29,7 @@ export interface StudyGroupDetailType {
   end_at: string
   max_headcount: number
   current_headcount: number
-  profile_img_url: string
+  profile_img_url: string | null
   status: StudyGroupStatus
   lectures: StudyGroupLectureType[]
   members: StudyGroupMemberType[]


### PR DESCRIPTION
## ✨ PR 개요

스터디 그룹 상세 페이지 MSW handler

## 📌 관련 이슈

Closes #134 

## 🧩 작업 내용 (주요 변경사항)

- 스터디 그룹 상세 페이지 API MSW 기반 핸들러 구현
- lectures 변경은 아직 반영하지 않았으며, 실제 API 연동 시 테스트 예정입니다.
- is_leader는 mock 환경에서 로그인 유저 상태를 대체하기 위한 임시 필드입니다.

## 💬 리뷰 포인트

## 📸 스크린샷 (선택)

## 🧠 기타 참고사항
- 이번 PR은 MSW 핸들러 구축까지이며,
  다음 PR에서 상세 페이지 UI와 실제 데이터 바인딩 및 동작 연결을 진행할 예정입니다.

## ✅ PR 체크리스트

- [ ] 커밋 컨벤션 준수 (예: `feat: 로그인 구현`)
- [ ] 불필요한 console.log 제거
- [ ] 로컬에서 실행 확인 완료
