### PR TITLE
Feature: 스터디 기록 생성/수정 페이지 MarkdownEditor 상태 연동

### DIFF
--- a/src/pages/CreateStudyNotePage.tsx
+++ b/src/pages/CreateStudyNotePage.tsx
@@ -12,6 +12,7 @@ export function CreateStudyNotePage() {
   const { groupId } = useParams<{ groupId: string }>()
   const navigate = useNavigate()
   const [title, setTitle] = useState('')
+  const [content, setContent] = useState('')
 
   const isInvalidParams = !groupId
 
@@ -27,11 +28,11 @@ export function CreateStudyNotePage() {
   if (isInvalidParams) return null
 
   const handleSubmit = () => {
-    // content, files, images는 아직 MarkdownEditor, FileUploader와 연동되지 않음
+    // files는 FileUploader와 연동되지 않음
     // API 형태에 맞추기 위해 빈 값으로 payload 생성
     const payload: CreateStudyNoteRequestType = {
       title,
-      content: '',
+      content,
       files: [],
       images: [],
     }
@@ -71,7 +72,7 @@ export function CreateStudyNotePage() {
           <label className="text-custom-gray-700 text-sm font-medium">
             내용 <span className="text-red-500">*</span>
           </label>
-          <MarkdownEditor />
+          <MarkdownEditor value={content} onChange={setContent} />
         </div>
 
         <div>

--- a/src/pages/DetailStudyNotePage.tsx
+++ b/src/pages/DetailStudyNotePage.tsx
@@ -1,4 +1,5 @@
 import { Button } from '@/components/common'
+import { Preview } from '@/components/markdown'
 import {
   BackToStudyGroupButton,
   StudyNoteAttachmentItem,
@@ -89,8 +90,8 @@ export function DetailStudyNotePage() {
         </section>
 
         {/* 본문 */}
-        <section className="border-b-custom-gray-200 border-b p-6">
-          <p>{data.content}</p>
+        <section className="border-b-custom-gray-200 border-b p-2">
+          <Preview value={data.content ?? ''} />
         </section>
 
         {/* 첨부 파일 */}

--- a/src/pages/EditStudyNotePage.tsx
+++ b/src/pages/EditStudyNotePage.tsx
@@ -12,6 +12,7 @@ export function EditStudyNotePage() {
   const { groupId, noteId } = useParams<{ groupId: string; noteId: string }>()
   const navigate = useNavigate()
   const [title, setTitle] = useState('')
+  const [content, setContent] = useState('')
 
   const isInvalidParams = !groupId || !noteId
 
@@ -29,15 +30,17 @@ export function EditStudyNotePage() {
   useEffect(() => {
     if (data) {
       setTitle(data.title)
+      setContent(data.content ?? '')
     }
   }, [data])
 
   if (isInvalidParams) return null
 
   const handleSubmit = () => {
-    // content, files는 아직 연동되지 않음
+    // files는 아직 연동되지 않음
     const payload: UpdateStudyNoteRequestType = {
       title,
+      content,
     }
 
     updateNote(payload, {
@@ -75,7 +78,7 @@ export function EditStudyNotePage() {
           <label className="text-custom-gray-700 text-sm font-medium">
             내용 <span className="text-red-500">*</span>
           </label>
-          <MarkdownEditor />
+          <MarkdownEditor value={content} onChange={setContent} />
         </div>
 
         <div>


### PR DESCRIPTION
## ✨ PR 개요

스터디 기록 생성/수정 페이지 MarkdownEditor 상태 연동

## 📌 관련 이슈

Closes #140

## 🧩 작업 내용 (주요 변경사항)

- 스터디 기록 생성/수정 페이지 MarkdownEditor 상태 연동
- 스터디 기록 상세 페이지에 Markdown 미리보기 적용

## 💬 리뷰 포인트

## 📸 스크린샷 (선택)

https://github.com/user-attachments/assets/931d11d3-669b-473d-b021-580124bc2a0d




## 🧠 기타 참고사항

## ✅ PR 체크리스트

- [ ] 커밋 컨벤션 준수 (예: `feat: 로그인 구현`)
- [ ] 불필요한 console.log 제거
- [ ] 로컬에서 실행 확인 완료
