### PR TITLE
feat: 스터디 그룹 상세페이지 리더 위임 버튼 기본 UI 구현

### DIFF
--- a/src/components/studygroup-detail/StudyMemberList.tsx
+++ b/src/components/studygroup-detail/StudyMemberList.tsx
@@ -1,5 +1,5 @@
 import { Badge, Card } from '@/components/common'
-import { UserRound } from 'lucide-react'
+import { Plus, UserRound, X } from 'lucide-react'
 
 export function StudyMemberList() {
   return (
@@ -8,13 +8,34 @@ export function StudyMemberList() {
         <p className="text-lg font-semibold">멤버 목록</p>
         <span className="text-custom-gray-500 text-sm">8명</span>
       </div>
+
       <ul className="flex max-h-[384px] flex-col gap-3 overflow-y-auto">
-        <li className="flex items-center gap-3">
-          <span className="bg-primary-100 centralize h-10 w-10 rounded-full">
-            <UserRound className="text-primary-600 h-5 w-5" />
-          </span>
-          <span>김개발</span>
-          <Badge className="h-6 rounded-sm">리더</Badge>
+        <li className="group flex justify-between">
+          <div className="flex items-center gap-3">
+            <span className="bg-primary-100 centralize h-10 w-10 rounded-full">
+              <UserRound className="text-primary-600 h-5 w-5" />
+            </span>
+            <span>김개발</span>
+            <Badge className="h-6 rounded-sm">리더</Badge>
+          </div>
+
+          {/* 리더 액션 버튼 */}
+          <div className="hidden items-center gap-3 text-sm group-hover:flex">
+            <button
+              type="button"
+              title="리더 위임"
+              className="text-primary-600 centralize bg-primary-100 h-7 w-7 rounded-full"
+            >
+              <Plus className="h-5 w-5" />
+            </button>
+            <button
+              type="button"
+              title="김개발님을 추방"
+              className="text-danger-600 centralize h-7 w-7 rounded-full bg-[#FEF2F2]"
+            >
+              <X className="h-5 w-5" />
+            </button>
+          </div>
         </li>
       </ul>
     </Card>


### PR DESCRIPTION
## ✨ PR 개요

스터디 그룹 상세페이지 리더 위임 버튼 기본 UI 구현

## 📌 관련 이슈

Closes #141 

## 🧩 작업 내용 (주요 변경사항)

- 스터디 그룹 상세페이지 리더 위임 버튼 기본 UI 구현
- 로직은 아직 미반영입니다!

## 💬 리뷰 포인트

## 📸 스크린샷 (선택)

https://github.com/user-attachments/assets/c69637a6-1a0e-43cf-aea1-9a075229ca43


## 🧠 기타 참고사항

## ✅ PR 체크리스트

- [ ] 커밋 컨벤션 준수 (예: `feat: 로그인 구현`)
- [ ] 불필요한 console.log 제거
- [ ] 로컬에서 실행 확인 완료
