### PR TITLE
feat: 404 에러에 표시할 fallback ui 라우터에 등록 (#145)

### DIFF
--- a/src/components/fallback-ui/NotFound.tsx
+++ b/src/components/fallback-ui/NotFound.tsx
@@ -1,26 +1,29 @@
 import { Button } from '@/components/common'
 import { ArrowRight } from 'lucide-react'
+import { Link } from 'react-router'
 
 export const NotFound = () => {
   return (
-    <div className="border-custom-gray-200 bg-custom-gray-50 m-6 flex h-[513px] items-center rounded-2xl border">
+    <div className="border-custom-gray-200 bg-custom-gray-50 m-6 flex h-[540px] items-center rounded-2xl border">
       <div className="w-full p-6 text-center">
         <h4 className="text-primary-500 text-[96px]">404</h4>
-        <p className="text-custom-gray-700 mb-4 text-[20px] font-bold">
+        <p className="text-custom-gray-700 mb-6 text-[20px] font-bold">
           찾으시는 페이지가 없습니다
         </p>
-
-        <div className="centralize h-[97px] text-center">
-          <p className="text-custom-gray-700 px-8 text-[16px] md:px-16 lg:px-32">
+        <div className="centralize h-28 flex-col gap-4 text-center">
+          <p className="text-custom-gray-700 px-8 text-sm md:px-16 md:text-base lg:px-32">
             방문하시려는 페이지의 주소가 잘못 입력되었거나, 삭제되어 사용하실 수
-            없습니다. 입력하신 주소가 정확한지 다시 한번 확인해 주세요.
+            없습니다.{' '}
+            <span className="sm:block">
+              입력하신 주소가 정확한지 다시 한번 확인해 주세요.
+            </span>
           </p>
-        </div>
-        <div>
-          <Button size="lg" variant="primary">
-            홈으로 가기
-            <ArrowRight size={20} className="ml-2" />
-          </Button>
+          <Link to="/">
+            <Button size="lg" variant="primary">
+              홈으로 가기
+              <ArrowRight size={20} className="ml-2" />
+            </Button>
+          </Link>
         </div>
       </div>
     </div>

--- a/src/routes/AppRoutes.tsx
+++ b/src/routes/AppRoutes.tsx
@@ -1,3 +1,4 @@
+import { NotFound } from '@/components/fallback-ui'
 import { Layout } from '@/components/layout'
 import {
   CreateStudyGroupPage,
@@ -29,6 +30,7 @@ export function AppRoutes() {
           path="study-groups/:groupId/notes/:noteId/edit"
           element={<EditStudyNotePage />}
         />
+        <Route path="*" element={<NotFound />} />
       </Route>
     </Routes>
   )


### PR DESCRIPTION
## ✨ PR 개요

<!-- 어떤 작업을 했는지 간략히 요약 -->
404 에러에 표시할 fallback ui 라우터에 등록

## 📌 관련 이슈

<!-- Closes #이슈번호 -->

Closes #145

## 🧩 작업 내용 (주요 변경사항)
- `NotFound` 컴포넌트  ui 수정 및 홈페이지와 연결
- 라우터에 컴포넌트 등록

## 💬 리뷰 포인트

<!-- 특히 봐줬으면 하는 부분 (예: 상태관리 로직 구조 괜찮은지 봐주세요) -->

## 📸 스크린샷 (선택)

<!-- UI 변경이 있다면 캡처나 GIF 첨부 -->
https://github.com/user-attachments/assets/6ff27163-46ab-4263-9f87-d384be968847

## 🧠 기타 참고사항

<!-- 추가로 알아야 할 점 (예: 임시로 넣은 더미 데이터 있음) -->

## ✅ PR 체크리스트

- [x] 커밋 컨벤션 준수 (예: `feat: 로그인 구현`)
- [x] 불필요한 console.log 제거
- [x] 로컬에서 실행 확인 완료
