### PR TITLE
style: 화면 크기에 따른 마크다운에디터 ui 조정 (#149)

### DIFF
--- a/src/components/markdown/MarkdownExample.tsx
+++ b/src/components/markdown/MarkdownExample.tsx
@@ -2,7 +2,7 @@ export function MarkdownExample() {
   return (
     <div className="text-custom-gray-600 border-custom-gray-200 bg-custom-gray-50 flex h-18 flex-col justify-center gap-2 rounded-b-lg border-t px-4 text-xs font-medium sm:h-12 md:h-8 md:flex-row md:items-center md:justify-start">
       <p className="font-normal">마크다운 문법을 사용할 수 있습니다.</p>
-      <div className="flex flex-col gap-0.5 sm:flex-row md:gap-2">
+      <div className="xs:text-xs flex flex-col gap-0.5 text-[10px] sm:flex-row md:gap-2">
         <div className="flex gap-2">
           <span>**굵게**</span>
           <span>*기울임*</span>

--- a/src/components/markdown/Toolbar.tsx
+++ b/src/components/markdown/Toolbar.tsx
@@ -19,7 +19,7 @@ export function Toolbar({ insertMarkdown }: ToolbarProps) {
           size="icon"
           onClick={() => insertMarkdown(before, after)}
         >
-          <Icon size={20} />
+          <Icon size={18} />
         </Button>
       ))}
       <ToolbarDropdownHeading insertMarkdown={insertMarkdown} />


### PR DESCRIPTION
## ✨ PR 개요

<!-- 어떤 작업을 했는지 간략히 요약 -->
화면 크기에 따른 마크다운에디터 ui 조정

## 📌 관련 이슈

<!-- Closes #이슈번호 -->

Closes #149

## 🧩 작업 내용 (주요 변경사항)
- 마크다운 예시 텍스트 사이즈 조정
- 툴바 아이콘 크기 조정

## 💬 리뷰 포인트

<!-- 특히 봐줬으면 하는 부분 (예: 상태관리 로직 구조 괜찮은지 봐주세요) -->

## 📸 스크린샷 (선택)

<!-- UI 변경이 있다면 캡처나 GIF 첨부 -->
<img width="365" height="408" alt="image" src="https://github.com/user-attachments/assets/39e7da0d-0c68-483f-b870-5d0c181ff738" />
화면 360px일때

## 🧠 기타 참고사항

<!-- 추가로 알아야 할 점 (예: 임시로 넣은 더미 데이터 있음) -->
비포 애프터 찍는거 깜빡했습니다...

## ✅ PR 체크리스트

- [x] 커밋 컨벤션 준수 (예: `feat: 로그인 구현`)
- [x] 로컬에서 실행 확인 완료
