### PR TITLE
feat: 스터디 그룹 페이지 로딩 ui 설정 (#165)

### DIFF
--- a/src/pages/StudyGroupPage.tsx
+++ b/src/pages/StudyGroupPage.tsx
@@ -1,4 +1,5 @@
 import { Button } from '@/components/common'
+import { Loading } from '@/components/fallback-ui'
 import { ReviewListModal, ReviewModal } from '@/components/review'
 import {
   StudyCard,
@@ -13,10 +14,22 @@ import { Link } from 'react-router'
 export function StudyGroupPage() {
   const { studies, selectedStudy, modal, fetchStudies } = useStudyGroupStore()
 
+  const [isLoading, setIsLoading] = useState(true)
   const [searchTerm, setSearchTerm] = useState('')
 
   useEffect(() => {
-    fetchStudies()
+    const loadData = async () => {
+      try {
+        setIsLoading(true)
+        await fetchStudies()
+      } catch (error) {
+        console.error('Failed to fetch studies', error)
+      } finally {
+        setIsLoading(false)
+      }
+    }
+
+    loadData()
   }, [fetchStudies])
 
   const filteredStudies = studies.filter((s) =>
@@ -44,47 +57,51 @@ export function StudyGroupPage() {
         </Link>
       </header>
       <StudyGroupSearchInput value={searchTerm} onChange={setSearchTerm} />
-      <section className="flex flex-col gap-8">
-        <StudySection
-          name="진행중인 스터디"
-          description="현재 활발히 진행되고 있는 스터디 그룹들"
-          badgeText={`${ongoingStudies.length}개 진행중`}
-          badgeColor="bg-success-100 text-success-700"
-          searchTerm={searchTerm}
-          items={ongoingStudies}
-          variant="onGoing"
-        >
-          {ongoingStudies.map((study) => (
-            <StudyCard key={study.id} study={study} />
-          ))}
-        </StudySection>
-        <StudySection
-          name="대기중 스터디"
-          description="스터디 기간이 시작되지 않은 스터디 그룹들"
-          badgeText={`${pendingStudies.length}개 대기중`}
-          badgeColor="bg-custom-gray-100 text-custom-gray-600"
-          searchTerm={searchTerm}
-          items={pendingStudies}
-          variant="pending"
-        >
-          {pendingStudies.map((study) => (
-            <StudyCard key={study.id} study={study} />
-          ))}
-        </StudySection>
-        <StudySection
-          name="완료된 스터디"
-          description="성공적으로 마무리된 스터디 그룹들"
-          badgeText={`${endedStudies.length}개 종료됨`}
-          badgeColor="bg-danger-100 text-danger-600"
-          searchTerm={searchTerm}
-          items={endedStudies}
-          variant="ended"
-        >
-          {endedStudies.map((study) => (
-            <StudyCard key={study.id} study={study} />
-          ))}
-        </StudySection>
-      </section>
+      {isLoading ? (
+        <Loading />
+      ) : (
+        <section className="flex flex-col gap-8">
+          <StudySection
+            name="진행중인 스터디"
+            description="현재 활발히 진행되고 있는 스터디 그룹들"
+            badgeText={`${ongoingStudies.length}개 진행중`}
+            badgeColor="bg-success-100 text-success-700"
+            searchTerm={searchTerm}
+            items={ongoingStudies}
+            variant="onGoing"
+          >
+            {ongoingStudies.map((study) => (
+              <StudyCard key={study.id} study={study} />
+            ))}
+          </StudySection>
+          <StudySection
+            name="대기중 스터디"
+            description="스터디 기간이 시작되지 않은 스터디 그룹들"
+            badgeText={`${pendingStudies.length}개 대기중`}
+            badgeColor="bg-custom-gray-100 text-custom-gray-600"
+            searchTerm={searchTerm}
+            items={pendingStudies}
+            variant="pending"
+          >
+            {pendingStudies.map((study) => (
+              <StudyCard key={study.id} study={study} />
+            ))}
+          </StudySection>
+          <StudySection
+            name="완료된 스터디"
+            description="성공적으로 마무리된 스터디 그룹들"
+            badgeText={`${endedStudies.length}개 종료됨`}
+            badgeColor="bg-danger-100 text-danger-600"
+            searchTerm={searchTerm}
+            items={endedStudies}
+            variant="ended"
+          >
+            {endedStudies.map((study) => (
+              <StudyCard key={study.id} study={study} />
+            ))}
+          </StudySection>
+        </section>
+      )}
       {selectedStudy && modal === 'list' && <ReviewListModal />}
       {selectedStudy && modal === 'edit' && <ReviewModal />}
     </div>


### PR DESCRIPTION
## ✨ PR 개요

<!-- 어떤 작업을 했는지 간략히 요약 -->
스터디 그룹 페이지 로딩 ui 설정

## 📌 관련 이슈

<!-- Closes #이슈번호 -->

Closes #165 

## 💬 리뷰 포인트

<!-- 특히 봐줬으면 하는 부분 (예: 상태관리 로직 구조 괜찮은지 봐주세요) -->

## 📸 스크린샷 (선택)

<!-- UI 변경이 있다면 캡처나 GIF 첨부 -->
https://github.com/user-attachments/assets/02a101cb-2f4a-4235-a7fd-32992cce5f94

## 🧠 기타 참고사항

<!-- 추가로 알아야 할 점 (예: 임시로 넣은 더미 데이터 있음) -->

## ✅ PR 체크리스트

- [x] 커밋 컨벤션 준수 (예: `feat: 로그인 구현`)
- [x] 불필요한 console.log 제거
- [x] 로컬에서 실행 확인 완료
