### PR TITLE
Feature: 채팅 WebSocket 타입 추가

### DIFF
--- a/src/constants/api.ts
+++ b/src/constants/api.ts
@@ -10,7 +10,7 @@ export const API_PATHS = {
     MESSAGES: (group_id: number | string) =>
       `/api/v1/chatrooms/${group_id}/messages`,
     READ: (group_id: number | string, member_id: number | string) =>
-      `/api/v1/chatroom/${group_id}/members/${member_id}/read`,
+      `/api/v1/chatrooms/${group_id}/members/${member_id}/read`,
   },
   REVIEW: {
     MSW_LIST: '/api/v1/study-groups/:groupId/reviews',

--- a/src/mocks/data/chat/chat-list.ts
+++ b/src/mocks/data/chat/chat-list.ts
@@ -4,6 +4,7 @@ export const mockChatList: ChatRoomListItem[] = [
   {
     id: 1,
     name: 'React 실무 프로젝트 스터디',
+    unread_message: 2,
     last_message: {
       id: 11,
       sender: { id: 1, nickname: '김개발' },
@@ -15,11 +16,13 @@ export const mockChatList: ChatRoomListItem[] = [
   {
     id: 2,
     name: 'Python 데이터 분석 스터디',
+    unread_message: 2,
     last_message: null,
   },
   {
     id: 3,
     name: 'AWS 클라우드 아키텍처 스터디',
+    unread_message: 2,
     last_message: {
       id: 12,
       sender: { id: 2, nickname: '박클라우드' },
@@ -31,6 +34,7 @@ export const mockChatList: ChatRoomListItem[] = [
   {
     id: 4,
     name: 'Node.js 백엔드 개발팀',
+    unread_message: 2,
     last_message: {
       id: 13,
       sender: { id: 3, nickname: '최서버' },
@@ -42,6 +46,7 @@ export const mockChatList: ChatRoomListItem[] = [
   {
     id: 5,
     name: '오즈 익스턴십 - 13기',
+    unread_message: 2,
     last_message: {
       id: 20,
       sender: { id: 3, nickname: '최서버' },

--- a/src/types/chat.ts
+++ b/src/types/chat.ts
@@ -44,10 +44,59 @@ export interface ChatMessage {
   created_at: string
 }
 
-// 채팅 참여자 (API 명세 확인 필요)
 export interface ChatParticipant {
   id: number
   nickname: string
   is_online?: boolean
   is_host?: boolean
+}
+
+// WebSocket 메시지 타입
+// 서버 → 클라이언트
+export type ChatServerMessageType =
+  | 'presence'
+  | 'user_join'
+  | 'user_leave'
+  | 'history'
+  | 'message'
+
+// 접속 직후 현재 참여자 목록
+export interface PresenceMessageType {
+  type: 'presence'
+  members: ChatParticipant[]
+}
+
+// 누군가 입장했을 때 broadcast
+export interface UserJoinMessageType {
+  type: 'user_join'
+  user: ChatParticipant
+}
+
+// 누군가 퇴장했을 때 broadcast
+export interface UserLeaveMessageType {
+  type: 'user_leave'
+  user: ChatParticipant
+}
+
+// 초기 메시지 목록
+export interface HistoryMessageType {
+  type: 'history'
+  messages: ChatMessage[]
+}
+
+// 새 메시지가 도착했을 때 broadcast
+export interface NewMessageType extends ChatMessage {
+  type: 'message'
+}
+
+export type ServerToClientWebSocketMsg =
+  | PresenceMessageType
+  | UserJoinMessageType
+  | UserLeaveMessageType
+  | HistoryMessageType
+  | NewMessageType
+
+// 클라이언트 → 서버
+export interface ChatMessageOutgoing {
+  content: string
 }

--- a/src/types/chat.ts
+++ b/src/types/chat.ts
@@ -1,4 +1,3 @@
-// GET /api/v1/chatrooms
 // 채팅방 목록 응답
 export interface ChatRoomListResponse {
   next: string | null
@@ -10,6 +9,7 @@ export interface ChatRoomListResponse {
 export interface ChatRoomListItem {
   id: number
   name: string
+  unread_message: number | null
   last_message: ChatRoomPreview | null
 }
 
@@ -23,10 +23,8 @@ export interface ChatRoomPreview {
   content: string
   is_read: boolean
   created_at: string
-  unread_count?: number // 추후 기획 업데이트 시 확인 필요
 }
 
-// GET /api/v1/chatrooms/{group_id}/messages
 // 특정 채팅방 메시지 목록 응답
 export interface ChatMessageResponse {
   next: string | null


### PR DESCRIPTION
## ✨ PR 개요

채팅 WebSocket 타입 추가

## 📌 관련 이슈

Closes #119

## 🧩 작업 내용 (주요 변경사항)

- 채팅 WebSocket 타입 정의 추가 
- `mockChatList`에서 누락된 `unread_message` 필드 보완

## 💬 리뷰 포인트

## 📸 스크린샷 (선택)

## 🧠 기타 참고사항

- 서버에서 presence 멤버 스키마가 확정되면 ChatParticipant 타입 조정이 필요할 수 있습니다!

## ✅ PR 체크리스트

- [ ] 커밋 컨벤션 준수 (예: `feat: 로그인 구현`)
- [ ] 불필요한 console.log 제거
- [ ] 로컬에서 실행 확인 완료
