### PR TITLE
Refactor: 날짜/시간 포맷 유틸 정리 및 스터디 상세 페이지 하위 라우트 수정

### DIFF
--- a/src/components/chat/list/ChatListItem.tsx
+++ b/src/components/chat/list/ChatListItem.tsx
@@ -1,6 +1,6 @@
 import { cn } from '@/lib'
 import type { ChatRoomListItem } from '@/types'
-import { formatChatListDate } from '@/utils'
+import { formatMonthDay } from '@/utils'
 
 interface ChatListItemProps {
   chatRoom: ChatRoomListItem
@@ -20,7 +20,7 @@ export function ChatListItem({
     : `(대화가 없습니다. 대화를 시작해보세요.)`
 
   const dateLabel = latestMessage
-    ? formatChatListDate(latestMessage.created_at)
+    ? formatMonthDay(latestMessage.created_at)
     : ''
 
   return (

--- a/src/components/chat/room/ChatMessageItem.tsx
+++ b/src/components/chat/room/ChatMessageItem.tsx
@@ -1,6 +1,6 @@
 import { CHAT_BUBBLE } from '@/constants'
 import type { ChatMessage } from '@/types'
-import { formatChatTime } from '@/utils'
+import { formatTimeHHmm } from '@/utils'
 
 interface ChatMessageItemProps {
   message: ChatMessage
@@ -12,7 +12,7 @@ export function ChatMessageItem({
   currentUserId,
 }: ChatMessageItemProps) {
   const isOutgoing = message.sender.id === currentUserId
-  const timeLabel = formatChatTime(message.created_at)
+  const timeLabel = formatTimeHHmm(message.created_at)
 
   // 내 메시지
   if (isOutgoing) {

--- a/src/components/studygroup-detail/StudyNoteList.tsx
+++ b/src/components/studygroup-detail/StudyNoteList.tsx
@@ -1,7 +1,7 @@
 import { Button, Card } from '@/components/common'
 import { LecturePagination } from '@/components/studygroup/lecture'
 import { useStudyNotes } from '@/hooks/study-note'
-import { format } from 'date-fns'
+import { formatDateTime } from '@/utils'
 import { Pencil, UserRound } from 'lucide-react'
 import { useEffect, useState } from 'react'
 import { useNavigate } from 'react-router'
@@ -64,7 +64,7 @@ export function StudyNoteList({ groupId }: StudyNoteListProps) {
                         {note.title}
                       </p>
                       <span className="text-custom-gray-500 text-sm">
-                        {format(new Date(note.created_at), 'yyyy. MM. dd.')}
+                        {formatDateTime(note.created_at)}
                       </span>
                     </div>
                     <div className="flex items-center gap-3 py-[2px]">

--- a/src/components/studygroup-detail/modal/ScheduleDetailModal.tsx
+++ b/src/components/studygroup-detail/modal/ScheduleDetailModal.tsx
@@ -1,6 +1,7 @@
 import { Badge, Button, Modal } from '@/components/common'
 import { useBodyScrollLock } from '@/hooks'
 import type { StudyScheduleDetailType } from '@/types'
+import { formatDateTime } from '@/utils'
 import { Calendar, Clock3, UserRound } from 'lucide-react'
 
 interface ScheduleDetailModalProps {
@@ -76,19 +77,25 @@ export function ScheduleDetailModal({
           참여자 목록 ({participantCount}명)
         </p>
         <ul className="border-custom-gray-200 flex max-h-[192px] min-h-24 flex-col gap-2 overflow-y-auto rounded-lg border p-4">
-          <li className="flex items-center gap-3">
-            <span className="bg-primary-100 centralize h-8 w-8 rounded-full">
-              <UserRound className="text-primary-600 h-[14px] w-[14px]" />
-            </span>
-            <span className="text-sm">김개발</span>
-            <Badge className="h-6 rounded-sm">리더</Badge>
-          </li>
+          {participants.map((member) => (
+            <li key={member.id} className="flex items-center gap-3">
+              <span className="bg-primary-100 centralize h-8 w-8 rounded-full">
+                <UserRound className="text-primary-600 h-[14px] w-[14px]" />
+              </span>
+              <span className="text-sm">{member.nickname}</span>
+              {member.is_leader && (
+                <Badge className="bg-primary-100 text-primary-800 h-6 rounded-sm px-2">
+                  리더
+                </Badge>
+              )}
+            </li>
+          ))}
         </ul>
       </div>
 
       <div className="border-custom-gray-200 flex w-full items-center justify-between gap-3 border-t pt-6">
         <span className="text-custom-gray-500 text-xs">
-          생성일: {schedule.created_at}
+          생성일: {formatDateTime(schedule.created_at)}
         </span>
         <div className="flex gap-3">
           <Button variant="primary" type="button" onClick={handleClickEdit}>

--- a/src/components/studygroup-note/BackToStudyGroupButton.tsx
+++ b/src/components/studygroup-note/BackToStudyGroupButton.tsx
@@ -9,7 +9,7 @@ export function BackToStudyGroupButton() {
   return (
     <Button
       variant="ghost"
-      onClick={() => navigate(`/study-groups/${groupId}`)}
+      onClick={() => navigate(`/${groupId}`)}
       className="w-1/2 justify-start"
     >
       <ArrowLeft className="pr-2" />

--- a/src/pages/CreateStudyNotePage.tsx
+++ b/src/pages/CreateStudyNotePage.tsx
@@ -39,7 +39,7 @@ export function CreateStudyNotePage() {
 
     createNote(payload, {
       onSuccess: () => {
-        navigate(`/study-groups/${groupId}`)
+        navigate(`/${groupId}`)
       },
     })
   }

--- a/src/pages/DetailStudyNotePage.tsx
+++ b/src/pages/DetailStudyNotePage.tsx
@@ -7,7 +7,7 @@ import {
 } from '@/components/studygroup-note'
 import { StudyNoteToggle } from '@/components/studygroup-note/StudyNoteToggle'
 import { useDeleteStudyNote, useStudyNoteDetail } from '@/hooks/study-note'
-import { format } from 'date-fns'
+import { formatDateTime } from '@/utils'
 import { Bot, Paperclip, UserRound } from 'lucide-react'
 import { useState } from 'react'
 import { useNavigate, useParams } from 'react-router'
@@ -23,13 +23,13 @@ export function DetailStudyNotePage() {
   const toggleSummary = () => setIsSummaryOpen((prev) => !prev)
 
   const handleEdit = () => {
-    navigate(`/study-groups/${groupId}/notes/${noteId}/edit`)
+    navigate(`/${groupId}/notes/${noteId}/edit`)
   }
 
   const handleDelete = () => {
     deleteNote(Number(noteId), {
       onSuccess: () => {
-        navigate(`/study-groups/${groupId}`)
+        navigate(`/${groupId}`)
       },
     })
   }
@@ -51,7 +51,7 @@ export function DetailStudyNotePage() {
               </Button>
               <Button
                 variant="danger"
-                className="text-danger-800 h-8 bg-[#FEE2E2]"
+                className="text-danger-800 h-8 bg-red-100 hover:bg-red-200 active:bg-red-300"
                 onClick={handleDelete}
               >
                 삭제하기
@@ -64,10 +64,7 @@ export function DetailStudyNotePage() {
             </span>
             <span>{data.author.nickname}</span>
             <span>&bull;</span>
-            <span>
-              작성일:{' '}
-              {format(new Date(data.created_at), 'yyyy. MM. dd. a h:mm')}
-            </span>
+            <span>작성일: {formatDateTime(data.updated_at)}</span>
           </p>
         </header>
 

--- a/src/pages/EditStudyNotePage.tsx
+++ b/src/pages/EditStudyNotePage.tsx
@@ -45,7 +45,7 @@ export function EditStudyNotePage() {
 
     updateNote(payload, {
       onSuccess: () => {
-        navigate(`/study-groups/${groupId}/notes/${noteId}`)
+        navigate(`/${groupId}/notes/${noteId}`)
       },
     })
   }

--- a/src/utils/format.ts
+++ b/src/utils/format.ts
@@ -1,20 +1,27 @@
 import { eachMinuteOfInterval, format } from 'date-fns'
 import { ko } from 'date-fns/locale'
 
-// 채팅방 목록 UI 날짜 - 0월 00일
-export function formatChatListDate(isoString: string) {
-  const date = new Date(isoString)
-  return `${date.getMonth() + 1}월 ${date.getDate()}일`
+// M월 d일
+export function formatMonthDay(dateStr: string) {
+  return format(new Date(dateStr), 'M월 d일', { locale: ko })
 }
 
-// 채팅 메시지 시간 - HH:mm
-export function formatChatTime(isoString: string) {
-  const date = new Date(isoString)
-  return date.toLocaleTimeString('ko-KR', {
-    hour: '2-digit',
-    minute: '2-digit',
-    hour12: false,
-  })
+// HH:mm
+export function formatTimeHHmm(dateStr: string) {
+  return format(new Date(dateStr), 'HH:mm', { locale: ko })
+}
+
+// yyyy. M. d.
+export function formatDotDate(dateStr: string) {
+  return format(new Date(dateStr), 'yyyy. M. d.', { locale: ko })
+}
+
+// yyyy. MM. dd. a h:mm
+export function formatDateTime(
+  dateStr: string,
+  pattern: string = 'yyyy. MM. dd. a h:mm'
+) {
+  return format(new Date(dateStr), pattern, { locale: ko })
 }
 
 // 새 스케줄 추가 시작/종료 시간
@@ -31,7 +38,7 @@ export function createTimeOptions(step = 10) {
     // 내부 로직 및 서버 요청에 사용되는 24시간제 시간 문자열 - 00:00
     value: format(date, 'HH:mm'),
     // UI 오전/오후 기반 12시간제 시간 문자열 - 오전/오후 0:00
-    label: format(date, 'a h:mm'),
+    label: format(date, 'a h:mm', { locale: ko }),
   }))
 }
 
@@ -40,11 +47,5 @@ export function formatMinutesToHHMM(minutes: number): string {
   const mins = minutes % 60
   const paddedHours = String(hours).padStart(2, '0')
   const paddedMinutes = String(mins).padStart(2, '0')
-
   return `${paddedHours}:${paddedMinutes}`
-}
-
-// 0000.0.0
-export function formatDotDate(dateStr: string) {
-  return format(new Date(dateStr), 'yyyy. M. d.', { locale: ko })
 }


### PR DESCRIPTION
## ✨ PR 개요

날짜/시간 포맷 공통 유틸 정리,
스터디 상세 페이지 내 하위 라우트 이동 경로 수정

## 📌 관련 이슈

Closes #175

## 🧩 작업 내용 (주요 변경사항)

- 날짜/시간 포맷 공통 유틸 함수로 정리
- 상세페이지 및 모달 등 하드코딩 된 날짜/시간 제거
- 스터디 상세 페이지 하위 라우트 경로 수정

## 💬 리뷰 포인트

## 📸 스크린샷 (선택)

https://github.com/user-attachments/assets/655d8565-6e71-4d89-a80c-ec8c6e6459cb


## 🧠 기타 참고사항

## ✅ PR 체크리스트

- [ ] 커밋 컨벤션 준수 (예: `feat: 로그인 구현`)
- [ ] 불필요한 console.log 제거
- [ ] 로컬에서 실행 확인 완료
