### PR TITLE
feat: 프로젝트에 전역 에러 바운더리 적용 (#189)

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -21,6 +21,7 @@
         "react-day-picker": "^9.11.2",
         "react-dom": "^19.1.0",
         "react-dropzone": "^14.3.8",
+        "react-error-boundary": "^6.0.0",
         "react-hook-form": "^7.67.0",
         "react-router": "^7.6.2",
         "react-toastify": "^11.0.5",
@@ -5484,6 +5485,18 @@
       },
       "peerDependencies": {
         "react": ">= 16.8 || 18.0.0"
+      }
+    },
+    "node_modules/react-error-boundary": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/react-error-boundary/-/react-error-boundary-6.0.0.tgz",
+      "integrity": "sha512-gdlJjD7NWr0IfkPlaREN2d9uUZUlksrfOx7SX62VRerwXbMY6ftGCIZua1VG1aXFNOimhISsTq+Owp725b9SiA==",
+      "license": "MIT",
+      "dependencies": {
+        "@babel/runtime": "^7.12.5"
+      },
+      "peerDependencies": {
+        "react": ">=16.13.1"
       }
     },
     "node_modules/react-hook-form": {

--- a/package.json
+++ b/package.json
@@ -24,6 +24,7 @@
     "react-day-picker": "^9.11.2",
     "react-dom": "^19.1.0",
     "react-dropzone": "^14.3.8",
+    "react-error-boundary": "^6.0.0",
     "react-hook-form": "^7.67.0",
     "react-router": "^7.6.2",
     "react-toastify": "^11.0.5",

--- a/src/components/fallback-ui/ErrorLayout.tsx
+++ b/src/components/fallback-ui/ErrorLayout.tsx
@@ -1,0 +1,31 @@
+import type { PropsWithChildren } from 'react'
+
+interface ErrorLayoutProps extends PropsWithChildren {
+  title: string
+  headline: string
+  description: string
+}
+
+export function ErrorLayout({
+  title,
+  headline,
+  description,
+  children,
+}: ErrorLayoutProps) {
+  return (
+    <div className="border-custom-gray-200 bg-custom-gray-50 m-6 flex h-[540px] items-center rounded-2xl border">
+      <div className="w-full p-6 text-center">
+        <h4 className="text-primary-500 text-[96px]">{title}</h4>
+        <p className="text-custom-gray-700 mb-6 text-[20px] font-bold">
+          {headline}
+        </p>
+        <div className="centralize h-28 flex-col gap-4 text-center">
+          <p className="text-custom-gray-700 px-8 text-sm md:px-16 md:text-base lg:px-32">
+            {description}
+          </p>
+          {children}
+        </div>
+      </div>
+    </div>
+  )
+}

--- a/src/components/fallback-ui/NotFound.tsx
+++ b/src/components/fallback-ui/NotFound.tsx
@@ -2,7 +2,7 @@ import { Button } from '@/components/common'
 import { ArrowRight } from 'lucide-react'
 import { Link } from 'react-router'
 
-export const NotFound = () => {
+export function NotFound() {
   return (
     <div className="border-custom-gray-200 bg-custom-gray-50 m-6 flex h-[540px] items-center rounded-2xl border">
       <div className="w-full p-6 text-center">

--- a/src/components/fallback-ui/PageError.tsx
+++ b/src/components/fallback-ui/PageError.tsx
@@ -1,0 +1,53 @@
+import { Button } from '@/components/common'
+import { ErrorLayout, NotFound } from '@/components/fallback-ui'
+import { useQueryClient } from '@tanstack/react-query'
+import { RefreshCcw } from 'lucide-react'
+import { useApiError } from '@/hooks'
+
+interface PageErrorProps {
+  error: unknown
+  resetErrorBoundary: () => void
+}
+
+export function PageError({ error, resetErrorBoundary }: PageErrorProps) {
+  const queryClient = useQueryClient()
+  const { isRenderable, status } = useApiError(error)
+
+  const handleRetry = () => {
+    queryClient.resetQueries()
+    resetErrorBoundary()
+  }
+
+  if (!isRenderable) return null
+
+  if (status === 404) {
+    return <NotFound />
+  }
+
+  if (status && status >= 500) {
+    return (
+      <ErrorLayout
+        title="500"
+        headline="서버 오류가 발생했습니다"
+        description="잠시 후 다시 시도해주세요."
+      >
+        <Button size="lg" variant="primary" onClick={handleRetry}>
+          <RefreshCcw size={16} className="mr-2" />
+          다시 시도
+        </Button>
+      </ErrorLayout>
+    )
+  }
+
+  return (
+    <ErrorLayout
+      title="ERROR"
+      headline="문제가 발생했습니다"
+      description="예기치 못한 오류가 발생했습니다."
+    >
+      <Button size="lg" variant="primary" onClick={handleRetry}>
+        새로고침
+      </Button>
+    </ErrorLayout>
+  )
+}

--- a/src/components/fallback-ui/index.ts
+++ b/src/components/fallback-ui/index.ts
@@ -1,3 +1,5 @@
+export * from './ErrorLayout'
 export * from './Loading'
 export * from './NoSearchData'
 export * from './NotFound'
+export * from './PageError'

--- a/src/hooks/index.ts
+++ b/src/hooks/index.ts
@@ -1,3 +1,4 @@
+export * from './useApiError'
 export * from './useLectures'
 export * from './useMarkdownEditor'
 export * from './chat'

--- a/src/hooks/useApiError.ts
+++ b/src/hooks/useApiError.ts
@@ -1,0 +1,48 @@
+import { useEffect, useMemo } from 'react'
+import { useNavigate } from 'react-router'
+import { toast } from 'react-toastify'
+import { ApiError } from '@/utils'
+
+export type ApiErrorAction =
+  | { type: 'redirect'; to: string }
+  | { type: 'back' }
+  | { type: 'render' }
+
+export function useApiError(error: unknown) {
+  const navigate = useNavigate()
+
+  const action = useMemo<ApiErrorAction>(() => {
+    if (!(error instanceof ApiError)) {
+      return { type: 'render' }
+    }
+
+    if (error.status === 401) {
+      return { type: 'redirect', to: '/login' }
+    }
+
+    if (error.status === 403) {
+      return { type: 'back' }
+    }
+
+    return { type: 'render' }
+  }, [error])
+
+  useEffect(() => {
+    if (!(error instanceof ApiError)) return
+
+    if (error.status === 401) {
+      toast.error('로그인이 필요합니다')
+      navigate('/login', { replace: true })
+    }
+
+    if (error.status === 403) {
+      toast.error('접근 권한이 없습니다')
+      navigate(-1)
+    }
+  }, [error, navigate])
+
+  return {
+    isRenderable: action.type === 'render',
+    status: error instanceof ApiError ? error.status : null,
+  }
+}

--- a/src/main.tsx
+++ b/src/main.tsx
@@ -19,7 +19,14 @@ async function enableMocking() {
 
 const root = createRoot(document.getElementById('root')!)
 
-const queryClient = new QueryClient()
+const queryClient = new QueryClient({
+  defaultOptions: {
+    queries: {
+      throwOnError: true,
+      retry: 1,
+    },
+  },
+})
 
 enableMocking().then(() => {
   root.render(

--- a/src/routes/AppRoutes.tsx
+++ b/src/routes/AppRoutes.tsx
@@ -1,4 +1,4 @@
-import { NotFound } from '@/components/fallback-ui'
+import { NotFound, PageError } from '@/components/fallback-ui'
 import { Layout } from '@/components/layout'
 import {
   CreateStudyNotePage,
@@ -8,13 +8,27 @@ import {
   StudyGroupFormPage,
   StudyGroupPage,
 } from '@/pages'
+import { ErrorBoundary } from 'react-error-boundary'
 
 import { Route, Routes } from 'react-router'
 
 export function AppRoutes() {
   return (
     <Routes>
-      <Route element={<Layout />}>
+      <Route
+        element={
+          <ErrorBoundary
+            fallbackRender={({ error, resetErrorBoundary }) => (
+              <PageError
+                error={error}
+                resetErrorBoundary={resetErrorBoundary}
+              />
+            )}
+          >
+            <Layout />
+          </ErrorBoundary>
+        }
+      >
         <Route index element={<StudyGroupPage />} />
         <Route path="/create" element={<StudyGroupFormPage />} />
         <Route path="/:groupId" element={<StudyDetailPage />} />

--- a/src/utils/fetcher.ts
+++ b/src/utils/fetcher.ts
@@ -1,0 +1,40 @@
+export class ApiError extends Error {
+  status: number
+  detail?: string
+
+  constructor(status: number, message: string, detail?: string) {
+    super(message)
+    this.name = 'ApiError'
+    this.status = status
+    this.detail = detail
+  }
+}
+
+export async function apiFetch<T>(
+  input: RequestInfo,
+  init?: RequestInit
+): Promise<T> {
+  const res = await fetch(input, init)
+
+  if (!res.ok) {
+    let errorBody = null
+
+    try {
+      errorBody = await res.json()
+    } catch {
+      // JSON 파싱 에러 무시
+    }
+
+    throw new ApiError(
+      res.status,
+      errorBody?.error_detail || '요청에 실패했습니다.',
+      errorBody
+    )
+  }
+
+  if (res.status === 204) {
+    return null as T
+  }
+
+  return res.json()
+}

--- a/src/utils/index.ts
+++ b/src/utils/index.ts
@@ -1,2 +1,3 @@
 export * from './calendar-localizer'
+export * from './fetcher'
 export * from './format'


### PR DESCRIPTION
## ✨ PR 개요

<!-- 어떤 작업을 했는지 간략히 요약 -->
프로젝트에 전역 에러 바운더리 적용

## 📌 관련 이슈

<!-- Closes #이슈번호 -->

Closes #189 

## 🧩 작업 내용 (주요 변경사항)
- 에러 타입(ApiError) 정리
- apiFetch 통합
- ErrorBoundary + PageError UI 생성
- TanStack Query랑 연결 구조 설계
- 401 / 403 / 404 / 5xx 정책 분리

## 💬 리뷰 포인트

<!-- 특히 봐줬으면 하는 부분 (예: 상태관리 로직 구조 괜찮은지 봐주세요) -->

## 📸 스크린샷 (선택)

<!-- UI 변경이 있다면 캡처나 GIF 첨부 -->

## 🧠 기타 참고사항

<!-- 추가로 알아야 할 점 (예: 임시로 넣은 더미 데이터 있음) -->
탠스택 쿼리랑 연결은 따로 해야함

## ✅ PR 체크리스트

- [x] 커밋 컨벤션 준수 (예: `feat: 로그인 구현`)
- [x] 불필요한 console.log 제거
