### PR TITLE
refactor: 채팅 WebSocket 연결 조건 정리 및 AuthStateStore 연동 

### DIFF
--- a/src/components/chat/ChatWidget.tsx
+++ b/src/components/chat/ChatWidget.tsx
@@ -6,6 +6,7 @@ import {
   useChatSocket,
 } from '@/hooks'
 import { useChatStore } from '@/store'
+import AuthStateStore from '@/store/authStateStore'
 import { MessageCircle, X } from 'lucide-react'
 
 export function ChatWidget() {
@@ -22,19 +23,25 @@ export function ChatWidget() {
   useBodyScrollLock(isOpen)
 
   const { chatRooms } = useChatRooms()
-
-  // 추후 로그인 연동
-  const mockAccessToken = 'MOCK_TOKEN'
-  const { status, participants, messages, sendMessage } = useChatSocket({
-    groupId: selectedGroupId ?? 0,
-    accessToken: mockAccessToken,
-  })
+  const accessToken = AuthStateStore((state) => state.accessToken)
 
   // 클릭한 채팅방 찾기
   const selectedRoom =
     selectedGroupId != null
       ? chatRooms.find((room) => room.id === selectedGroupId)
       : null
+
+  const isRoomView = currentView === 'room' && !!selectedRoom
+  const isLoggedIn = !!accessToken && currentUserId !== null
+
+  const socketEnabled = isOpen && isRoomView && isLoggedIn
+  const canRenderRoom = isRoomView && isLoggedIn
+
+  const { status, participants, messages, sendMessage } = useChatSocket({
+    groupId: selectedGroupId ?? 0,
+    accessToken,
+    enabled: socketEnabled,
+  })
 
   // 위젯 버튼 클릭
   const handleClickWidget = () => {
@@ -46,23 +53,9 @@ export function ChatWidget() {
     openGroup(groupId)
   }
 
-  // 채팅방에서 리스트로 돌아가기
-  const handleBackToList = () => {
-    openList()
-  }
-
   // 패널 닫기
   const handleClosePanel = () => {
     toggleOpen()
-  }
-
-  // 채팅방 화면을 렌더링할 수 있는 조건
-  const canRenderRoom =
-    currentView === 'room' && selectedRoom && currentUserId !== null
-
-  // 메세지 전송 핸들러
-  const handleSendMessage = (message: string) => {
-    sendMessage(message)
   }
 
   // 미읽음 메세지
@@ -81,16 +74,28 @@ export function ChatWidget() {
             />
           )}
 
+          {currentView === 'room' && selectedRoom && !accessToken && (
+            <div className="text-custom-gray-600 flex h-full items-center justify-center p-4 text-sm">
+              로그인 후 채팅을 이용할 수 있어요.
+            </div>
+          )}
+
+          {socketEnabled && status === SocketStatus.CONNECTING && (
+            <div className="text-custom-gray-600 flex h-full items-center justify-center p-4 text-sm">
+              채팅방에 연결 중...
+            </div>
+          )}
+
           {/* 채팅방 View */}
           {canRenderRoom && status === SocketStatus.OPEN && (
             <ChatRoomPanel
               roomName={selectedRoom.name}
               participants={participants}
-              messages={messages || []}
-              currentUserId={currentUserId}
-              onClose={handleClosePanel}
-              onSend={handleSendMessage}
-              onBack={handleBackToList}
+              messages={messages}
+              currentUserId={currentUserId!}
+              onClose={toggleOpen}
+              onSend={sendMessage}
+              onBack={openList}
             />
           )}
         </div>

--- a/src/hooks/chat/useChatSocket.ts
+++ b/src/hooks/chat/useChatSocket.ts
@@ -8,6 +8,7 @@ import { useEffect, useRef, useState } from 'react'
 interface UseChatSocketOptions {
   groupId: number
   accessToken?: string | null
+  enabled?: boolean
 }
 
 export enum SocketStatus {
@@ -17,14 +18,18 @@ export enum SocketStatus {
   ERROR = 'error',
 }
 
-export function useChatSocket({ groupId, accessToken }: UseChatSocketOptions) {
+export function useChatSocket({
+  groupId,
+  accessToken,
+  enabled = true,
+}: UseChatSocketOptions) {
   const socketRef = useRef<WebSocket | null>(null)
   const [status, setStatus] = useState<SocketStatus>(SocketStatus.CLOSED)
   const [participants, setParticipants] = useState<ChatParticipant[]>([])
   const [messages, setMessages] = useState<ChatMessage[]>([])
 
   useEffect(() => {
-    if (!accessToken || !groupId) return
+    if (!accessToken || !groupId || !enabled) return
 
     setStatus(SocketStatus.CONNECTING)
 
@@ -77,7 +82,7 @@ export function useChatSocket({ groupId, accessToken }: UseChatSocketOptions) {
       socket.close()
       socketRef.current = null
     }
-  }, [groupId, accessToken])
+  }, [groupId, accessToken, enabled])
 
   // 클라이언트 → 서버 메시지 전송
   const sendMessage = (content: string) => {


### PR DESCRIPTION
## ✨ PR 개요

채팅 WebSocket 연결 조건 정리 및 AuthStateStore 연동 

## 📌 관련 이슈

Closes #185

## 🧩 작업 내용 (주요 변경사항)

- 채팅 WebSocket 연결에서 사용하던 mock accessToken을 제거, 
AuthStateStore의 accessToken을 사용하도록 연동
- 채팅 위젯 오픈 + 채팅방 진입 + 로그인 상태일 때만
WebSocket이 연결되도록 조건 정리

## 💬 리뷰 포인트

## 📸 스크린샷 (선택)

## 🧠 기타 참고사항


## ✅ PR 체크리스트

- [ ] 커밋 컨벤션 준수 (예: `feat: 로그인 구현`)
- [ ] 불필요한 console.log 제거
- [ ] 로컬에서 실행 확인 완료
