### PR TITLE
feat: API 인증 설정 및 토큰 자동 갱신 처리

### DIFF
--- a/src/api/auth/login.ts
+++ b/src/api/auth/login.ts
@@ -1,0 +1,12 @@
+import { API_BASE_URL, API_PATHS } from '@/constants'
+import axios from 'axios'
+
+const refreshClient = axios.create({
+  baseURL: API_BASE_URL,
+  withCredentials: true,
+  headers: { 'Content-Type': 'application/json' },
+})
+
+export const refreshAccessToken = () => {
+  return refreshClient.post(API_PATHS.USER.REFRESH_TOKEN, {})
+}

--- a/src/api/auth/login.ts
+++ b/src/api/auth/login.ts
@@ -1,8 +1,10 @@
 import { API_BASE_URL, API_PATHS } from '@/constants'
 import axios from 'axios'
 
+const IS_DEV = import.meta.env.MODE === 'development'
+
 const refreshClient = axios.create({
-  baseURL: API_BASE_URL,
+  baseURL: IS_DEV ? '' : API_BASE_URL,
   withCredentials: true,
   headers: { 'Content-Type': 'application/json' },
 })

--- a/src/api/axios.ts
+++ b/src/api/axios.ts
@@ -44,13 +44,16 @@ axiosInstance.interceptors.response.use(
         originalRequest.headers.Authorization = `Bearer ${newToken}`
 
         return axiosInstance(originalRequest)
-      } catch {
+      } catch (refreshError) {
         // 갱신 실패 시 토큰 제거
         AuthStateStore.getState().clearAuth()
         LoginStateStore.getState().setLoginState('GUEST')
-        window.location.href = EXTERNAL_LINKS.LOGIN
 
-        return Promise.reject(error)
+        // 개발환경에서는 리다이렉트 안 함
+        if (!IS_DEV) {
+          window.location.href = EXTERNAL_LINKS.LOGIN
+        }
+        return Promise.reject(refreshError)
       }
     }
 

--- a/src/api/axios.ts
+++ b/src/api/axios.ts
@@ -5,6 +5,7 @@ const IS_DEV = import.meta.env.MODE === 'development'
 
 export const axiosInstance = axios.create({
   baseURL: IS_DEV ? '' : API_BASE_URL,
+  withCredentials: true,
   headers: {
     'Content-Type': 'application/json',
   },

--- a/src/api/axios.ts
+++ b/src/api/axios.ts
@@ -1,4 +1,7 @@
-import { API_BASE_URL } from '@/constants'
+import { refreshAccessToken } from '@/api/auth/login'
+import { API_BASE_URL, EXTERNAL_LINKS } from '@/constants'
+import { LoginStateStore } from '@/store'
+import AuthStateStore from '@/store/authStateStore'
 import axios from 'axios'
 
 const IS_DEV = import.meta.env.MODE === 'development'
@@ -10,3 +13,53 @@ export const axiosInstance = axios.create({
     'Content-Type': 'application/json',
   },
 })
+
+// 요청 시 accessToken이 있으면 Authorization 헤더에 자동으로 추가
+axiosInstance.interceptors.request.use((config) => {
+  const token = AuthStateStore.getState().accessToken
+  if (token) {
+    config.headers = config.headers ?? {}
+    config.headers.Authorization = `Bearer ${token}`
+  }
+  return config
+})
+
+axiosInstance.interceptors.response.use(
+  (response) => response,
+  async (error) => {
+    const originalRequest = error.config
+
+    // 401이고 재시도 아닐 때만
+    if (error.response?.status === 401 && !originalRequest._retry) {
+      originalRequest._retry = true
+
+      try {
+        // 엑세스 토큰 재발급
+        const { data } = await refreshAccessToken()
+        const newToken = data.access_token
+
+        AuthStateStore.getState().setAccessToken(newToken)
+
+        originalRequest.headers = originalRequest.headers ?? {}
+        originalRequest.headers.Authorization = `Bearer ${newToken}`
+
+        return axiosInstance(originalRequest)
+      } catch {
+        // 갱신 실패 시 토큰 제거
+        AuthStateStore.getState().clearAuth()
+        LoginStateStore.getState().setLoginState('GUEST')
+        window.location.href = EXTERNAL_LINKS.LOGIN
+
+        return Promise.reject(error)
+      }
+    }
+
+    if (error.response?.data) {
+      return Promise.reject({
+        ...error.response.data,
+        statusCode: error.response.status,
+      })
+    }
+    return Promise.reject(error)
+  }
+)

--- a/src/constants/api.ts
+++ b/src/constants/api.ts
@@ -4,6 +4,7 @@ export const API_PATHS = {
   USER: {
     // 유저 정보를 가져오는 api
     GET: '/api/v1/accounts/me',
+    REFRESH_TOKEN: '/api/v1/accounts/token/refresh',
   },
   CHAT: {
     ROOMS: '/api/v1/chatrooms',

--- a/src/mocks/handler.ts
+++ b/src/mocks/handler.ts
@@ -1,12 +1,12 @@
 import { MSW_BASE_URL } from '@/constants'
 import {
+  authHandlers,
   chatHandlers,
   lectureHandlers,
   noteHandlers,
   reviewHandlers,
   scheduleHandlers,
   studygroupHandlers,
-  userInformationHandler,
 } from '@/mocks/handlers'
 import { studygroupDetailHandlers } from '@/mocks/handlers/studygroup-details-handler'
 import { http, HttpResponse } from 'msw'
@@ -24,5 +24,5 @@ export const handlers = [
   ...scheduleHandlers,
   ...studygroupHandlers,
   ...studygroupDetailHandlers,
-  ...userInformationHandler,
+  ...authHandlers,
 ]

--- a/src/mocks/handlers/user-handler.ts
+++ b/src/mocks/handlers/user-handler.ts
@@ -2,8 +2,15 @@ import { http, HttpResponse } from 'msw'
 import { userInformation } from '@/mocks/data'
 import { API_PATHS } from '@/constants'
 
-export const userInformationHandler = [
-  http.get(API_PATHS.USER.GET, () => {
-    return HttpResponse.json(userInformation)
-  }),
-]
+export const userInformationHandler = http.get(API_PATHS.USER.GET, () => {
+  return HttpResponse.json(userInformation)
+})
+
+export const refreshTokenHandler = http.post(
+  API_PATHS.USER.REFRESH_TOKEN,
+  () => {
+    return HttpResponse.json({ access_token: 'mock-new-access-token' })
+  }
+)
+
+export const authHandlers = [userInformationHandler, refreshTokenHandler]

--- a/src/store/authStateStore.ts
+++ b/src/store/authStateStore.ts
@@ -1,13 +1,25 @@
 import { create } from 'zustand'
+import { persist } from 'zustand/middleware'
 
 type AuthState = {
   accessToken: string | null
   setAccessToken: (token: string | null) => void
+  clearAuth: () => void
 }
 
-const AuthStateStore = create<AuthState>((set) => ({
-  accessToken: null,
-  setAccessToken: (token) => set({ accessToken: token }),
-}))
+const AuthStateStore = create<AuthState>()(
+  persist(
+    (set) => ({
+      accessToken: null,
+      setAccessToken: (token) => set({ accessToken: token }),
+      clearAuth: () => set({ accessToken: null }),
+    }),
+    {
+      name: 'auth-storage',
+      // persist 시 accessToken만 저장
+      partialize: (state) => ({ accessToken: state.accessToken }),
+    }
+  )
+)
 
 export default AuthStateStore


### PR DESCRIPTION
## ✨ PR 개요

API 인증 설정 및 토큰 자동 갱신 처리

## 📌 관련 이슈

Closes #190

## 🧩 작업 내용 (주요 변경사항)

- axios 전역 인증 인터셉터 구성
  - 요청 시 accessToken 자동 Authorization 헤더 주입
  - 401 응답 발생 시 refresh token 기반 accessToken 재발급 및 재요청 처리
- 인증 실패 시 인증 상태 초기화 및 로그인 페이지로 리다이렉트
- 인증 관련 API 경로 상수화 및 MSW 토큰 갱신 mock 핸들러 추가

## 💬 리뷰 포인트

- 현재 `LoginState`가 `AuthStateStore`와 역할이 일부 중복되는 상태입니다.
여러 컴포넌트에서 이미 사용중이라 이번 PR에서는 구조 변경 없이 인증 로직 추가에 집중했습니다!


## 📸 스크린샷 (선택)


https://github.com/user-attachments/assets/52a9ecca-61b7-46bb-9edc-e68b0f03deef



## 🧠 기타 참고사항

```ts
let once = true // 1회 401

export const userInformationHandler = http.get(API_PATHS.USER.GET, () => {
  if (once) {
    once = false
    return new HttpResponse(null, { status: 401 })
  }
  return HttpResponse.json(userInformation)
})

// export const userInformationHandler = http.get(API_PATHS.USER.GET, () => {
//   return HttpResponse.json(userInformation)
// })
```
- 위 임시 코드로 401 → refresh → 재요청 흐름 확인했습니다!



## ✅ PR 체크리스트

- [ ] 커밋 컨벤션 준수 (예: `feat: 로그인 구현`)
- [ ] 불필요한 console.log 제거
- [ ] 로컬에서 실행 확인 완료
