### PR TITLE
feat: axios baseURL 정리 및 개발 환경용 로그인 플로우 추가

### DIFF
--- a/src/api/auth/devLogin.ts
+++ b/src/api/auth/devLogin.ts
@@ -1,0 +1,18 @@
+import { axiosInstance } from '@/api/axios'
+import { API_PATHS } from '@/constants'
+
+type DevLoginResponse = {
+  access_token: string
+}
+
+export async function devLogin(email: string, password: string) {
+  if (!import.meta.env.DEV) {
+    throw new Error('devLogin은 개발 환경에서만 사용할 수 있습니다.')
+  }
+
+  const res = await axiosInstance.post<DevLoginResponse>(API_PATHS.USER.LOGIN, {
+    email,
+    password,
+  })
+  return res.data.access_token
+}

--- a/src/api/auth/login.ts
+++ b/src/api/auth/login.ts
@@ -1,10 +1,8 @@
 import { API_BASE_URL, API_PATHS } from '@/constants'
 import axios from 'axios'
 
-const IS_DEV = import.meta.env.MODE === 'development'
-
 const refreshClient = axios.create({
-  baseURL: IS_DEV ? '' : API_BASE_URL,
+  baseURL: API_BASE_URL,
   withCredentials: true,
   headers: { 'Content-Type': 'application/json' },
 })

--- a/src/api/axios.ts
+++ b/src/api/axios.ts
@@ -1,13 +1,11 @@
 import { refreshAccessToken } from '@/api/auth/login'
-import { API_BASE_URL, EXTERNAL_LINKS } from '@/constants'
+import { API_BASE_URL } from '@/constants'
 import { LoginStateStore } from '@/store'
 import AuthStateStore from '@/store/authStateStore'
 import axios from 'axios'
 
-const IS_DEV = import.meta.env.MODE === 'development'
-
 export const axiosInstance = axios.create({
-  baseURL: IS_DEV ? '' : API_BASE_URL,
+  baseURL: API_BASE_URL,
   withCredentials: true,
   headers: {
     'Content-Type': 'application/json',
@@ -49,10 +47,6 @@ axiosInstance.interceptors.response.use(
         AuthStateStore.getState().clearAuth()
         LoginStateStore.getState().setLoginState('GUEST')
 
-        // 개발환경에서는 리다이렉트 안 함
-        if (!IS_DEV) {
-          window.location.href = EXTERNAL_LINKS.LOGIN
-        }
         return Promise.reject(refreshError)
       }
     }

--- a/src/components/layout/header/Header.tsx
+++ b/src/components/layout/header/Header.tsx
@@ -3,6 +3,8 @@ import { LoginStateStore } from '@/store'
 import { Guest, MobileModal, User } from '@/components/layout'
 import { Menu } from 'lucide-react'
 import { EXTERNAL_LINKS } from '@/constants'
+import AuthStateStore from '@/store/authStateStore'
+import { devLogin } from '@/api/auth/devLogin'
 
 interface HeaderProps {
   isSideBarOpen: boolean
@@ -13,6 +15,23 @@ export function Header({ isSideBarOpen, setIsSideBarOpen }: HeaderProps) {
   const loginState = LoginStateStore((state) => state.loginState)
   const handleSideBar = () => {
     setIsSideBarOpen(!isSideBarOpen)
+  }
+
+  // API 연결 시 임시 버튼
+  const accessToken = AuthStateStore((state) => state.accessToken)
+
+  const handleDevLogin = async () => {
+    const token = await devLogin(
+      import.meta.env.VITE_DEV_EMAIL!,
+      import.meta.env.VITE_DEV_PASSWORD!
+    )
+    AuthStateStore.getState().setAccessToken(token)
+    LoginStateStore.getState().setLoginState('USER')
+  }
+
+  const handleDevLogout = () => {
+    AuthStateStore.getState().clearAuth()
+    LoginStateStore.getState().setLoginState('GUEST')
   }
 
   return (
@@ -35,6 +54,15 @@ export function Header({ isSideBarOpen, setIsSideBarOpen }: HeaderProps) {
             <h2 className="text-primary-500 text-2xl font-bold">StudyHub</h2>
           </div>
         </a>
+        {/* dev 전용 로그인 버튼 */}
+        {import.meta.env.DEV && (
+          <button
+            onClick={accessToken ? handleDevLogout : handleDevLogin}
+            className="rounded bg-red-500 px-2 py-1 text-xs text-white"
+          >
+            {accessToken ? 'DEVLOGOUT' : 'DEVLOGIN'}
+          </button>
+        )}
         {/* 로그인 하지 않았을때의 UI */}
         {loginState === 'GUEST' && <Guest />}
         {/* 로그인 했을때 UI */}

--- a/src/constants/api.ts
+++ b/src/constants/api.ts
@@ -4,6 +4,7 @@ export const API_PATHS = {
   USER: {
     // 유저 정보를 가져오는 api
     GET: '/api/v1/accounts/me',
+    LOGIN: '/api/v1/accounts/login',
     REFRESH_TOKEN: '/api/v1/accounts/token/refresh',
   },
   LOGOUT: {

--- a/src/store/loginStateStore.ts
+++ b/src/store/loginStateStore.ts
@@ -1,4 +1,5 @@
 import { create } from 'zustand'
+import { persist } from 'zustand/middleware'
 
 type LoginState = 'GUEST' | 'USER'
 
@@ -8,9 +9,16 @@ interface LoginStore {
 }
 
 // 로그인 상태를 저장하는 로직 => 추후 사용할때 setLoginState('USER')
-export const LoginStateStore = create<LoginStore>((set) => ({
-  loginState: 'USER',
-  setLoginState: (state) => {
-    set({ loginState: state })
-  },
-}))
+export const LoginStateStore = create<LoginStore>()(
+  persist(
+    (set) => ({
+      loginState: 'GUEST',
+      setLoginState: (state) => {
+        set({ loginState: state })
+      },
+    }),
+    {
+      name: 'login-state-storage',
+    }
+  )
+)


### PR DESCRIPTION
## ✨ PR 개요

axios baseURL 정리 및 개발 환경용 로그인 플로우 추가

## 📌 관련 이슈

Closes #224

## 🧩 작업 내용 (주요 변경사항)

- axios baseURL을 환경에서도 실서버(API_BASE_URL)를 사용하도록 통일
- 개발 환경 전용 devLogin 유틸 및 Header에 DEVLOGIN / DEVLOGOUT 버튼 추가
- 로그인 상태에 persist 적용하여 새로고침 시 상태 유지

## 💬 리뷰 포인트

## 📸 스크린샷 (선택)

https://github.com/user-attachments/assets/d1dfb226-3fdc-41ec-a652-304832afdfe8

## 🧠 기타 참고사항

- `StudyGroupPage`에서  `studies.filter(...)` 호출 시 `studies`가 undefined로 들어오면서 런타임 에러가 발생하고 있습니다. 
현재 작업 진행을 위해서 로컬에는 이전 파일 기준으로 임시 복구 후 작업을 진행했습니다! 
(해당 임시 복구 내용은 PR에는 포함되어 있지 않습니다)

## ✅ PR 체크리스트

- [ ] 커밋 컨벤션 준수 (예: `feat: 로그인 구현`)
- [ ] 불필요한 console.log 제거
- [ ] 로컬에서 실행 확인 완료
