### PR TITLE
fix: 스터디 종료일이 시작일 이전으로 선택되지 않도록 제한 (#229)

### DIFF
--- a/src/components/date-picker/DatePickerModal.tsx
+++ b/src/components/date-picker/DatePickerModal.tsx
@@ -12,6 +12,7 @@ import './date-picker.css'
 
 interface DatePickerModalProps {
   isOpen: boolean
+  disabled?: { before: Date }
   selected?: Date
   onClose: () => void
   onChange: (date: Date | undefined) => void
@@ -20,8 +21,9 @@ interface DatePickerModalProps {
 
 export function DatePickerModal({
   isOpen,
-  onClose,
+  disabled,
   selected,
+  onClose,
   onChange,
   onConfirm,
 }: DatePickerModalProps) {
@@ -46,7 +48,7 @@ export function DatePickerModal({
         navLayout="around"
         selected={selected}
         onSelect={onChange}
-        disabled={{ before: new Date() }}
+        disabled={disabled}
         showOutsideDays
         components={{
           CaptionLabel: (captionProps) => (

--- a/src/components/studygroup/StudyGroupMemberSlider.tsx
+++ b/src/components/studygroup/StudyGroupMemberSlider.tsx
@@ -132,6 +132,11 @@ export function StudyGroupMemberSlider() {
       </section>
       <DatePickerModal
         isOpen={isModalOpen}
+        disabled={
+          activeField === 'end' && startDate
+            ? { before: new Date(startDate) }
+            : { before: new Date() }
+        }
         selected={
           activeField === 'start'
             ? startDate
@@ -149,10 +154,12 @@ export function StudyGroupMemberSlider() {
         }}
         onChange={(date) => {
           if (!activeField) return
-          setValue(
-            activeField === 'start' ? 'start_at' : 'end_at',
-            date?.toISOString() ?? ''
-          )
+          if (activeField === 'start') {
+            setValue('start_at', date?.toISOString() ?? '')
+            setValue('end_at', '')
+          } else {
+            setValue('end_at', date?.toISOString() ?? '')
+          }
         }}
         onConfirm={() => {
           setIsModalOpen(false)

--- a/src/schema/studygroup.ts
+++ b/src/schema/studygroup.ts
@@ -1,13 +1,30 @@
 import z from 'zod'
 
-export const studyGroupSchema = z.object({
-  name: z.string().min(1, '스터디 이름을 입력해주세요'),
-  introduction: z.string().optional(),
-  start_at: z.string().min(1, '시작일을 선택하세요'),
-  end_at: z.string().min(1, '종료일을 선택하세요'),
-  max_headcount: z.number().min(2, '최소 인원은 2명입니다').max(10),
-  profile_img_url: z.string().optional(),
-  lectures: z.array(z.number()).max(5, '강의는 최대 5개까지 선택가능'),
-})
+export const studyGroupSchema = z
+  .object({
+    name: z.string().min(1, '스터디 이름을 입력해주세요'),
+    introduction: z.string().optional(),
+    start_at: z.string().min(1, '시작일을 선택하세요'),
+    end_at: z.string().min(1, '종료일을 선택하세요'),
+    max_headcount: z.number().min(2, '최소 인원은 2명입니다').max(10),
+    profile_img_url: z.string().optional(),
+    profile_image_file: z.instanceof(File).optional(), // File 객체 저장용
+    lectures: z.array(z.number()).max(5, '강의는 최대 5개까지 선택가능'),
+  })
+
+  .superRefine((data, ctx) => {
+    if (!data.start_at || !data.end_at) return
+
+    const start = new Date(data.start_at)
+    const end = new Date(data.end_at)
+
+    if (start > end) {
+      ctx.addIssue({
+        path: ['end_at'],
+        message: '종료일은 시작일 이후여야 합니다',
+        code: z.ZodIssueCode.custom,
+      })
+    }
+  })
 
 export type StudyGroupForm = z.infer<typeof studyGroupSchema>


### PR DESCRIPTION
## ✨ PR 개요

<!-- 어떤 작업을 했는지 간략히 요약 -->
스터디 종료일이 시작일 이전으로 선택되지 않도록 제한

## 📌 관련 이슈

<!-- Closes #이슈번호 -->

Closes #229 

## 🧩 작업 내용 (주요 변경사항)
- Zod `superRefine`를 통한 검증
- `DatePicker` 단계에서의 선택 제한
- 시작일 변경 시 종료일 초기화 UX 처리

## 💬 리뷰 포인트

<!-- 특히 봐줬으면 하는 부분 (예: 상태관리 로직 구조 괜찮은지 봐주세요) -->

## 📸 스크린샷 (선택)

<!-- UI 변경이 있다면 캡처나 GIF 첨부 -->

## 🧠 기타 참고사항

<!-- 추가로 알아야 할 점 (예: 임시로 넣은 더미 데이터 있음) -->

## ✅ PR 체크리스트

- [x] 커밋 컨벤션 준수 (예: `feat: 로그인 구현`)
- [x] 불필요한 console.log 제거
- [x] 로컬에서 실행 확인 완료
