### PR TITLE
fix: 리뷰 목록 미표시 및 수정 후 상태 미반영 문제 해결 (#253)

### DIFF
--- a/src/api/studygroup.ts
+++ b/src/api/studygroup.ts
@@ -19,13 +19,10 @@ export async function getStudyGroups() {
 
 // 스터디 그룹 리뷰 조회
 export async function getStudyReviews(studyId: number) {
-  const { data } = await axiosInstance.get<{
-    reviews: StudyGroupReviewType[]
-    average_rating: number
-    total_count: number
-  }>(API_PATHS.REVIEW.LIST(studyId))
-
-  return data
+  const res = await axiosInstance<StudyGroupReviewType[]>(
+    API_PATHS.REVIEW.LIST(studyId)
+  )
+  return res.data
 }
 
 // 스터디 그룹 생성

--- a/src/components/review/ReviewListModal.tsx
+++ b/src/components/review/ReviewListModal.tsx
@@ -1,14 +1,17 @@
 import { Button, Modal } from '@/components/common'
+import { Loading } from '@/components/fallback-ui'
 import { StarRating } from '@/components/review'
-import { useStudyReviews } from '@/hooks/review/useStudyReviews'
+import { useStudyReviews } from '@/hooks/review'
 import { useStudyGroupStore } from '@/store'
 import { formatDotDate } from '@/utils'
-import { Loading } from '../fallback-ui'
+import type { StudyGroupReviewType } from '@/types'
 
 export function ReviewListModal() {
   const { selectedStudy, modal, openReviewCreate, openReviewEdit, closeModal } =
     useStudyGroupStore()
-  const { data, isLoading } = useStudyReviews(selectedStudy!.id ?? 0)
+  const { data: reviews = [], isLoading } = useStudyReviews(
+    selectedStudy!.id ?? 0
+  )
 
   if (!selectedStudy) return null
 
@@ -20,13 +23,16 @@ export function ReviewListModal() {
     )
   }
 
-  const reviews = data?.reviews ?? []
-  const reviewStats = {
-    average: data?.average_rating ?? 0,
-    total: data?.total_count ?? 0,
-  }
+  const total = reviews.length
+  const average =
+    total === 0
+      ? 0
+      : reviews.reduce(
+          (sum: number, r: StudyGroupReviewType) => sum + r.star_rating,
+          0
+        ) / total
 
-  const myReview = reviews.find((r) => r.is_mine)
+  const myReview = reviews.find((r: StudyGroupReviewType) => r.is_mine)
 
   return (
     <Modal
@@ -41,17 +47,13 @@ export function ReviewListModal() {
         <p className="text-custom-gray-500 text-xs">{selectedStudy.name}</p>
         <div className="mt-6 flex flex-col items-center justify-center gap-2">
           <div className="flex gap-2">
-            <StarRating
-              rating={Math.round(reviewStats.average)}
-              readonly
-              size={24}
-            />
+            <StarRating rating={Math.round(average)} readonly size={24} />
             <span className="text-custom-gray-900 text-2xl font-bold">
-              {reviewStats.average}
+              {average}
             </span>
           </div>
           <div className="text-custom-gray-400 text-sm">
-            총 {reviewStats.total}개의 리뷰
+            총 {total}개의 리뷰
           </div>
         </div>
       </div>

--- a/src/components/review/ReviewModal.tsx
+++ b/src/components/review/ReviewModal.tsx
@@ -3,6 +3,7 @@ import { Button, Modal } from '@/components/common'
 import { StarRating } from '@/components/review'
 import { useStudyGroupStore } from '@/store'
 import { useReviewMutation } from '@/hooks/review'
+import { formatYearMonthDay } from '@/utils'
 
 export function ReviewModal() {
   const { selectedStudy, selectedReview, modal, closeModal } =
@@ -55,7 +56,8 @@ export function ReviewModal() {
           {selectedStudy.name}
         </h1>
         <p className="text-custom-gray-500 mt-2 text-sm">
-          {selectedStudy.start_at} ~ {selectedStudy.end_at}
+          {formatYearMonthDay(selectedStudy.start_at)} ~{' '}
+          {formatYearMonthDay(selectedStudy.end_at)}
         </p>
       </div>
       <div className="py-2">

--- a/src/hooks/review/useReviewMutation.ts
+++ b/src/hooks/review/useReviewMutation.ts
@@ -4,6 +4,15 @@ import { useMutation, useQueryClient } from '@tanstack/react-query'
 export function useReviewMutation(studyId: number) {
   const queryClient = useQueryClient()
 
+  const REVIEW_KEYS = {
+    list: () => ['studyReviews'],
+    detail: (studyId: number) => ['studyReview', studyId],
+  }
+
+  const STUDY_KEYS = {
+    list: () => ['studyGroups'],
+  }
+
   return useMutation({
     mutationFn: async ({
       reviewId,
@@ -21,9 +30,9 @@ export function useReviewMutation(studyId: number) {
     },
 
     onSuccess: () => {
-      queryClient.invalidateQueries({
-        queryKey: ['studyReviews', studyId],
-      })
+      queryClient.invalidateQueries({ queryKey: REVIEW_KEYS.list() })
+      queryClient.invalidateQueries({ queryKey: REVIEW_KEYS.detail(studyId) })
+      queryClient.invalidateQueries({ queryKey: STUDY_KEYS.list() })
     },
   })
 }

--- a/src/hooks/review/useStudyReviews.ts
+++ b/src/hooks/review/useStudyReviews.ts
@@ -1,9 +1,10 @@
 import { getStudyReviews } from '@/api'
+import type { StudyGroupReviewType } from '@/types'
 import { ApiError } from '@/utils'
 import { useQuery } from '@tanstack/react-query'
 
 export function useStudyReviews(studyId: number) {
-  return useQuery({
+  return useQuery<StudyGroupReviewType[]>({
     queryKey: ['studyReviews', studyId],
     queryFn: () => getStudyReviews(studyId),
     enabled: !!studyId,


### PR DESCRIPTION
## ✨ PR 개요

<!-- 어떤 작업을 했는지 간략히 요약 -->
리뷰 목록 미표시 및 수정 후 상태 미반영 문제 해결

## 📌 관련 이슈

<!-- Closes #이슈번호 -->

Closes #253 

## 🧩 작업 내용 (주요 변경사항)
- 리뷰 조회 API 응답 구조 변경으로 인해 리뷰 목록이 표시되지 않던 문제 수정
- `axios` 응답 처리 및 `useStudyReviews` 훅 타입 정리로 데이터 매핑 안정화
- 리뷰 목록/평점 관련 계산 로직을 실제 API 응답 기준으로 수정
- 리뷰 작성·수정 후 리뷰 목록 및 스터디 그룹 평점이 즉시 반영되도록 query invalidate 처리
- 리뷰 모달에서 날짜 렌더링 ui 수정

## 💬 리뷰 포인트

<!-- 특히 봐줬으면 하는 부분 (예: 상태관리 로직 구조 괜찮은지 봐주세요) -->

## 📸 스크린샷 (선택)

<!-- UI 변경이 있다면 캡처나 GIF 첨부 -->
https://github.com/user-attachments/assets/2fc2d1c9-ac2f-46c5-824e-5ff58f4dd529

## 🧠 기타 참고사항

<!-- 추가로 알아야 할 점 (예: 임시로 넣은 더미 데이터 있음) -->

## ✅ PR 체크리스트

- [x] 커밋 컨벤션 준수 (예: `feat: 로그인 구현`)
- [x] 불필요한 console.log 제거
- [x] 로컬에서 실행 확인 완료
