### PR TITLE
fix: 스터디 그룹 수정시 해당 스터디 그룹의 상세페이지로 이동하도록 라우팅 (#261)

### DIFF
--- a/src/hooks/study-group/useUpdateStudyGroup.ts
+++ b/src/hooks/study-group/useUpdateStudyGroup.ts
@@ -1,11 +1,15 @@
 import { updateStudyGroup } from '@/api/studygroup'
+import { showToast } from '@/lib'
 import type { StudyGroupDetailType, UpdateStudyGroupRequestType } from '@/types'
+import { ApiError } from '@/utils'
 import { useMutation, useQueryClient } from '@tanstack/react-query'
 import type { AxiosError } from 'axios'
+import { useNavigate } from 'react-router'
 
 // 스터디 그룹 수정
 export const useUpdateStudyGroup = (groupId: string | number) => {
   const queryClient = useQueryClient()
+  const navigate = useNavigate()
 
   return useMutation<
     StudyGroupDetailType,
@@ -24,6 +28,7 @@ export const useUpdateStudyGroup = (groupId: string | number) => {
       })
 
       showToast.success('수정 성공!', '스터디 그룹이 수정되었습니다')
+      navigate(`/${groupId}`)
     },
 
     onError: (error) => {


### PR DESCRIPTION
## ✨ PR 개요

<!-- 어떤 작업을 했는지 간략히 요약 -->
스터디 그룹 수정시 해당 스터디 그룹의 상세페이지로 이동하도록 라우팅

## 📌 관련 이슈

<!-- Closes #이슈번호 -->

Closes #261 

## 💬 리뷰 포인트

<!-- 특히 봐줬으면 하는 부분 (예: 상태관리 로직 구조 괜찮은지 봐주세요) -->

## 📸 스크린샷 (선택)

<!-- UI 변경이 있다면 캡처나 GIF 첨부 -->
https://github.com/user-attachments/assets/206b2624-0e0d-40b7-b382-e7c8e9fc514a

## 🧠 기타 참고사항

<!-- 추가로 알아야 할 점 (예: 임시로 넣은 더미 데이터 있음) -->

## ✅ PR 체크리스트

- [x] 커밋 컨벤션 준수 (예: `feat: 로그인 구현`)
- [x] 불필요한 console.log 제거
- [x] 로컬에서 실행 확인 완료
