### PR TITLE
fix: API 에러 응답 구조 통합 및 스터디 그룹 에러 UX 개선 (#263)

### DIFF
--- a/src/api/axios.ts
+++ b/src/api/axios.ts
@@ -55,7 +55,8 @@ axiosInstance.interceptors.response.use(
       return Promise.reject(
         new ApiError(
           status,
-          data?.error_detail || data?.message || '요청에 실패했습니다',
+          data?.message || '요청에 실패했습니다',
+          data?.error_detail,
           data
         )
       )

--- a/src/hooks/study-group/useCreateStudyGroup.ts
+++ b/src/hooks/study-group/useCreateStudyGroup.ts
@@ -22,7 +22,7 @@ export function useCreateStudyGroup() {
 
     onError: (error) => {
       if (error instanceof ApiError) {
-        showToast.error('실패!', error.message)
+        showToast.error('실패!', error.getFirstMessage())
       } else {
         showToast.error('스터디 생성 실패!', '스터디 생성에 실패했습니다')
       }

--- a/src/hooks/study-group/useUpdateStudyGroup.ts
+++ b/src/hooks/study-group/useUpdateStudyGroup.ts
@@ -33,7 +33,7 @@ export const useUpdateStudyGroup = (groupId: string | number) => {
 
     onError: (error) => {
       if (error instanceof ApiError) {
-        showToast.error('실패!', error.message)
+        showToast.error('실패!', error.getFirstMessage())
       } else {
         showToast.error('스터디 수정 실패!', '스터디 수정에 실패했습니다')
       }

--- a/src/pages/StudyGroupFormPage.tsx
+++ b/src/pages/StudyGroupFormPage.tsx
@@ -15,6 +15,7 @@ import { studyGroupSchema, type StudyGroupForm } from '@/schema'
 import { useEffect } from 'react'
 import { FormProvider, useForm } from 'react-hook-form'
 import { useNavigate, useParams } from 'react-router'
+import { showToast } from '@/lib'
 
 export function StudyGroupFormPage() {
   const navigate = useNavigate()
@@ -59,13 +60,21 @@ export function StudyGroupFormPage() {
     groupId!
   )
 
-  const onSubmit = methods.handleSubmit((formData) => {
-    if (isEdit) {
-      updateStudy(formData)
-    } else {
-      createStudy(formData)
+  const onSubmit = methods.handleSubmit(
+    (formData) => {
+      if (isEdit) {
+        updateStudy(formData)
+      } else {
+        createStudy(formData)
+      }
+    },
+    (errors) => {
+      const firstError = Object.values(errors)[0]
+      if (firstError?.message) {
+        showToast.error('입력 오류', firstError.message)
+      }
     }
-  })
+  )
 
   return (
     <FormProvider {...methods}>

--- a/src/schema/studygroup.ts
+++ b/src/schema/studygroup.ts
@@ -2,14 +2,18 @@ import z from 'zod'
 
 export const studyGroupSchema = z
   .object({
-    name: z.string().min(1, '스터디 이름을 입력해주세요'),
-    introduction: z.string().optional(),
+    name: z
+      .string()
+      .trim()
+      .min(1, '스터디 이름을 입력해주세요')
+      .max(30, '스터디 이름은 30자 이내여야 합니다'),
+    introduction: z.string().max(300).optional(),
     start_at: z.string().min(1, '시작일을 선택하세요'),
     end_at: z.string().min(1, '종료일을 선택하세요'),
-    max_headcount: z.number().min(2, '최소 인원은 2명입니다').max(10),
+    max_headcount: z.number(),
     profile_img_url: z.string().optional(),
     profile_image_file: z.instanceof(File).optional(), // File 객체 저장용
-    lectures: z.array(z.number()).max(5, '강의는 최대 5개까지 선택가능'),
+    lectures: z.array(z.number()).max(5, '강의는 최대 5개까지 선택 가능합니다'),
   })
 
   .superRefine((data, ctx) => {

--- a/src/utils/apiError.ts
+++ b/src/utils/apiError.ts
@@ -1,11 +1,24 @@
 export class ApiError extends Error {
   status: number
-  detail?: string
+  detail?: Record<string, string[]>
+  raw?: unknown
 
-  constructor(status: number, message: string, detail?: string) {
+  constructor(
+    status: number,
+    message: string,
+    detail?: Record<string, string[]>,
+    raw?: unknown
+  ) {
     super(message)
     this.name = 'ApiError'
     this.status = status
     this.detail = detail
+    this.raw = raw
+  }
+
+  getFirstMessage() {
+    if (!this.detail) return this.message
+    const firstField = Object.values(this.detail)[0]
+    return firstField?.[0] ?? this.message
   }
 }


### PR DESCRIPTION
## ✨ PR 개요

<!-- 어떤 작업을 했는지 간략히 요약 -->
API 에러 응답 구조 통합 및 스터디 그룹 에러 UX 개선

## 📌 관련 이슈

<!-- Closes #이슈번호 -->

Closes #263 

## 🧩 작업 내용 (주요 변경사항)
- `axiosInstance`에서 API 에러 구조 정규화
- `apiError` 유틸 개선
- 스터디 생성/수정 시 중복 이름 에러를 토스트로 노출
- `schema` / `form` 쪽 에러 UX 개선

## 💬 리뷰 포인트

<!-- 특히 봐줬으면 하는 부분 (예: 상태관리 로직 구조 괜찮은지 봐주세요) -->

## 📸 스크린샷 (선택)

<!-- UI 변경이 있다면 캡처나 GIF 첨부 -->
https://github.com/user-attachments/assets/6979905b-4049-4eb9-ac7d-c87ac76bea48

## 🧠 기타 참고사항

<!-- 추가로 알아야 할 점 (예: 임시로 넣은 더미 데이터 있음) -->

## ✅ PR 체크리스트

- [x] 커밋 컨벤션 준수 (예: `feat: 로그인 구현`)
- [x] 불필요한 console.log 제거
- [x] 로컬에서 실행 확인 완료
