### PR TITLE
fix: 로그인 후 ChatWidget, Header UI 업데이트 안 되는 문제

### DIFF
--- a/src/components/layout/header/Header.tsx
+++ b/src/components/layout/header/Header.tsx
@@ -13,12 +13,14 @@ interface HeaderProps {
 
 export function Header({ isSideBarOpen, setIsSideBarOpen }: HeaderProps) {
   const loginState = LoginStateStore((state) => state.loginState)
+  const accessToken = AuthStateStore((state) => state.accessToken)
+  const isLoggedIn = loginState === 'USER' || !!accessToken
+
   const handleSideBar = () => {
     setIsSideBarOpen(!isSideBarOpen)
   }
 
   // API 연결 시 임시 버튼
-  const accessToken = AuthStateStore((state) => state.accessToken)
 
   const handleDevLogin = async () => {
     const token = await devLogin(
@@ -64,9 +66,9 @@ export function Header({ isSideBarOpen, setIsSideBarOpen }: HeaderProps) {
           </button>
         )}
         {/* 로그인 하지 않았을때의 UI */}
-        {loginState === 'GUEST' && <Guest />}
+        {!isLoggedIn && <Guest />}
         {/* 로그인 했을때 UI */}
-        {loginState === 'USER' && <User />}
+        {isLoggedIn && <User />}
       </div>
     </div>
   )

--- a/src/components/studygroup-detail/StudyDetailHero.tsx
+++ b/src/components/studygroup-detail/StudyDetailHero.tsx
@@ -6,15 +6,21 @@ import { Calendar, LogOutIcon, Pencil, UsersRound } from 'lucide-react'
 
 interface StudyDetailHeroProps {
   group: StudyGroupDetailType
+  currentUserId: number
   onClickEdit: () => void
   onClickLeave: () => void
 }
 
 export function StudyDetailHero({
   group,
+  currentUserId,
   onClickEdit,
   onClickLeave,
 }: StudyDetailHeroProps) {
+  const isLeader = group.members.some(
+    (member) => member.id === currentUserId && member.is_leader
+  )
+
   return (
     <section className="border-custom-gray-200 overflow-hidden rounded-xl border">
       <div className="relative aspect-[16/9] w-full md:h-[480px] lg:h-[608px]">
@@ -34,14 +40,16 @@ export function StudyDetailHero({
         <div className="absolute inset-0 flex flex-col justify-between p-6">
           {/* 상단 버튼 */}
           <div className="flex justify-end gap-3">
-            <Button
-              variant="secondary"
-              className="gap-2 text-base"
-              onClick={onClickEdit}
-            >
-              <Pencil className="h-4 w-4" />
-              <span>수정하기</span>
-            </Button>
+            {isLeader && (
+              <Button
+                variant="secondary"
+                className="gap-2 text-base"
+                onClick={onClickEdit}
+              >
+                <Pencil className="h-4 w-4" />
+                <span>수정하기</span>
+              </Button>
+            )}
             <Button
               variant="danger"
               className="gap-2 text-base"

--- a/src/hooks/queries/useUserData.ts
+++ b/src/hooks/queries/useUserData.ts
@@ -1,13 +1,17 @@
 import { getUserInformationApi } from '@/api'
 import { LoginStateStore } from '@/store'
+import AuthStateStore from '@/store/authStateStore'
 import type { UserInformation } from '@/types'
 import { useQuery } from '@tanstack/react-query'
 
 export const useUserData = () => {
   const loginState = LoginStateStore((state) => state.loginState)
+  const accessToken = AuthStateStore((state) => state.accessToken)
+  const isLoggedIn = loginState === 'USER' || !!accessToken
+
   return useQuery<UserInformation>({
     queryKey: ['userData'],
     queryFn: getUserInformationApi,
-    enabled: loginState === 'USER',
+    enabled: isLoggedIn,
   })
 }

--- a/src/pages/StudyDetailPage.tsx
+++ b/src/pages/StudyDetailPage.tsx
@@ -58,6 +58,7 @@ export function StudyDetailPage() {
       {/* 상단 히어로 */}
       <StudyDetailHero
         group={group}
+        currentUserId={currentUserId}
         onClickEdit={handleClickEdit}
         onClickLeave={handleClickLeave}
       />


### PR DESCRIPTION
## ✨ PR 개요
로그인 후 ChatWidget, Header UI 업데이트 안 되는 문제


## 📌 관련 이슈

Closes #270

## 🧩 작업 내용 (주요 변경사항)

- 로그인 후에도 우측 하단 위젯이 표시되지 않음
- 로그인 후에도 로그인/회원가입 버튼이 계속 표시됨

## 💬 리뷰 포인트

## 📸 스크린샷 (선택)

## 🧠 기타 참고사항

배포 후 테스트 진행 예정

## ✅ PR 체크리스트

- [ ] 커밋 컨벤션 준수 (예: `feat: 로그인 구현`)
- [ ] 불필요한 console.log 제거
- [ ] 로컬에서 실행 확인 완료
