### PR TITLE
fix: 멀티 도메인 환경에서 인증 상태 불일치 문제 해결

### DIFF
--- a/src/api/axios.ts
+++ b/src/api/axios.ts
@@ -38,6 +38,7 @@ axiosInstance.interceptors.response.use(
         const newToken = data.access_token
 
         AuthStateStore.getState().setAccessToken(newToken)
+        LoginStateStore.getState().setLoginState('USER')
 
         originalRequest.headers = originalRequest.headers ?? {}
         originalRequest.headers.Authorization = `Bearer ${newToken}`

--- a/src/components/layout/Layout.tsx
+++ b/src/components/layout/Layout.tsx
@@ -1,9 +1,10 @@
+import { refreshAccessToken } from '@/api/auth/login'
 import { ChatWidget } from '@/components/chat'
 import { Footer, Header } from '@/components/layout'
 import { ScrollToTop } from '@/hooks'
 import { LoginStateStore } from '@/store'
 import AuthStateStore from '@/store/authStateStore'
-import { useState } from 'react'
+import { useEffect, useState } from 'react'
 import { Outlet } from 'react-router'
 
 export function Layout() {
@@ -12,6 +13,25 @@ export function Layout() {
   const accessToken = AuthStateStore((state) => state.accessToken)
 
   const isLoggedIn = loginState === 'USER' || !!accessToken
+
+  // 초기 진입 시 refresh 시도
+  useEffect(() => {
+    const initAuth = async () => {
+      const currentToken = AuthStateStore.getState().accessToken
+
+      if (!currentToken) {
+        try {
+          const { data } = await refreshAccessToken()
+          AuthStateStore.getState().setAccessToken(data.access_token)
+          LoginStateStore.getState().setLoginState('USER')
+        } catch {
+          LoginStateStore.getState().setLoginState('GUEST')
+        }
+      }
+    }
+
+    initAuth()
+  }, [])
 
   return (
     <div className="flex min-h-screen w-full flex-col items-center">

--- a/src/hooks/queries/useUserData.ts
+++ b/src/hooks/queries/useUserData.ts
@@ -1,15 +1,17 @@
 import { getUserInformationApi } from '@/api'
 import { LoginStateStore } from '@/store'
+import AuthStateStore from '@/store/authStateStore'
 
 import type { UserInformation } from '@/types'
 import { useQuery } from '@tanstack/react-query'
 
 export const useUserData = () => {
   const loginState = LoginStateStore((state) => state.loginState)
+  const accessToken = AuthStateStore((state) => state.accessToken)
 
   return useQuery<UserInformation>({
     queryKey: ['userData'],
     queryFn: getUserInformationApi,
-    enabled: loginState === 'USER',
+    enabled: loginState === 'USER' || !!accessToken,
   })
 }


### PR DESCRIPTION
## ✨ PR 개요

멀티 도메인 환경에서 인증 상태 불일치 문제 해결

## 📌 관련 이슈

Closes #296

## 🧩 작업 내용 (주요 변경사항)

- axios interceptor 개선: refreshToken 재발급 성공 시 `loginState`를 `'USER'`로 자동 설정
- useUserData enabled 조건 확장: `loginState === 'USER'` 조건 외에 `accessToken` 존재 여부도 체크하여 더 유연하게 API 호출 가능
- Layout 초기 인증 로직 추가: Study 도메인 첫 진입 시 `localStorage`에 토큰이 없으면 `refreshToken` 쿠키를 사용해 자동으로 `accessToken` 발급


## 💬 리뷰 포인트

## 📸 스크린샷 (선택)

## 🧠 기타 참고사항

- `localhost`는 서브도메인이 없어서 멀티 도메인 확인이 불가능해, 배포 후 테스트 진행 예정입니다!


## ✅ PR 체크리스트

- [ ] 커밋 컨벤션 준수 (예: `feat: 로그인 구현`)
- [ ] 불필요한 console.log 제거
- [ ] 로컬에서 실행 확인 완료
