### PR TITLE
fix: localStorage에 토큰 있을 때 loginState 동기화 추가

### DIFF
--- a/src/components/layout/Layout.tsx
+++ b/src/components/layout/Layout.tsx
@@ -14,18 +14,25 @@ export function Layout() {
 
   const isLoggedIn = loginState === 'USER' || !!accessToken
 
-  // 초기 진입 시 refresh 시도
+  // 초기 진입 시 인증 상태 확인
   useEffect(() => {
     const initAuth = async () => {
       const currentToken = AuthStateStore.getState().accessToken
 
       if (!currentToken) {
+        // 토큰 없으면 refreshToken으로 발급 시도
         try {
           const { data } = await refreshAccessToken()
           AuthStateStore.getState().setAccessToken(data.access_token)
           LoginStateStore.getState().setLoginState('USER')
         } catch {
           LoginStateStore.getState().setLoginState('GUEST')
+        }
+      } else {
+        // 토큰 있으면 loginState 동기화
+        const currentLoginState = LoginStateStore.getState().loginState
+        if (currentLoginState !== 'USER') {
+          LoginStateStore.getState().setLoginState('USER')
         }
       }
     }


### PR DESCRIPTION
## ✨ PR 개요

localStorage에 토큰 있을 때 loginState 동기화 누락

## 📌 관련 이슈

Closes #298

## 🧩 작업 내용 (주요 변경사항)

- Layout.tsx 수정: `accessToken`이 localStorage에 존재할 때 `loginState`를 'USER'로 동기화하는 로직 추가

## 💬 리뷰 포인트

## 📸 스크린샷 (선택)

## 🧠 기타 참고사항

## ✅ PR 체크리스트

- [ ] 커밋 컨벤션 준수 (예: `feat: 로그인 구현`)
- [ ] 불필요한 console.log 제거
- [ ] 로컬에서 실행 확인 완료
