### PR TITLE
fix: 스터디 그룹 수정하기 버튼 로직 수정 

### DIFF
--- a/src/components/studygroup-detail/StudyDetailHero.tsx
+++ b/src/components/studygroup-detail/StudyDetailHero.tsx
@@ -6,12 +6,14 @@ import { Calendar, LogOutIcon, Pencil, UsersRound } from 'lucide-react'
 
 interface StudyDetailHeroProps {
   group: StudyGroupDetailType
+  isCurrentUserLeader: boolean
   onClickEdit: () => void
   onClickLeave: () => void
 }
 
 export function StudyDetailHero({
   group,
+  isCurrentUserLeader,
   onClickEdit,
   onClickLeave,
 }: StudyDetailHeroProps) {
@@ -34,14 +36,16 @@ export function StudyDetailHero({
         <div className="absolute inset-0 flex flex-col justify-between p-6">
           {/* 상단 버튼 */}
           <div className="flex justify-end gap-3">
-            <Button
-              variant="secondary"
-              className="gap-2 text-base"
-              onClick={onClickEdit}
-            >
-              <Pencil className="h-4 w-4" />
-              <span>수정하기</span>
-            </Button>
+            {isCurrentUserLeader && (
+              <Button
+                variant="secondary"
+                className="gap-2 text-base"
+                onClick={onClickEdit}
+              >
+                <Pencil className="h-4 w-4" />
+                <span>수정하기</span>
+              </Button>
+            )}
             <Button
               variant="danger"
               className="gap-2 text-base"

--- a/src/pages/StudyDetailPage.tsx
+++ b/src/pages/StudyDetailPage.tsx
@@ -17,8 +17,7 @@ export function StudyDetailPage() {
   const numericGroupId = Number(groupId)
   const navigate = useNavigate()
 
-  const { isLoading: isUserLoading } = useUserData()
-
+  const { data: userData, isLoading: isUserLoading } = useUserData()
   const { data: group, isLoading: isGroupLoading } =
     useStudyGroupDetail(numericGroupId)
   const { mutate: leaveStudyGroup } = useLeaveStudyGroup()
@@ -26,13 +25,26 @@ export function StudyDetailPage() {
   if (isUserLoading || isGroupLoading) {
     return <Loading />
   }
-  if (!group) return null
+  if (!group || !userData) return null
+
+  const isCurrentUserLeader = group.members.some(
+    (member) => member.nickname === userData.nickname && member.is_leader
+  )
 
   const handleClickEdit = () => {
     navigate(`/${numericGroupId}/edit`)
   }
 
   const handleClickLeave = () => {
+    // 리더면 위임 요청 알림
+    if (isCurrentUserLeader) {
+      showToast.warning(
+        '리더 위임 필요',
+        '그룹을 나가기 전에 다른 멤버에게 리더를 위임해주세요.'
+      )
+      return
+    }
+
     leaveStudyGroup(numericGroupId, {
       onSuccess: () => {
         showToast.success(
@@ -42,10 +54,7 @@ export function StudyDetailPage() {
         navigate('/')
       },
       onError: () => {
-        showToast.error(
-          '스터디 나가기 실패',
-          '리더는 스터디 그룹을 나갈 수 없습니다.'
-        )
+        showToast.error('스터디 나가기 실패', '스터디 그룹을 찾을 수 없습니다.')
       },
     })
   }
@@ -55,6 +64,7 @@ export function StudyDetailPage() {
       {/* 상단 히어로 */}
       <StudyDetailHero
         group={group}
+        isCurrentUserLeader={isCurrentUserLeader}
         onClickEdit={handleClickEdit}
         onClickLeave={handleClickLeave}
       />


### PR DESCRIPTION
## ✨ PR 개요

스터디 그룹 수정하기 버튼 로직 수정 

## 📌 관련 이슈

Closes #300

## 🧩 작업 내용 (주요 변경사항)

- 현재 유저의 리더 여부 확인 로직 추가 (nickname 비교)
- 리더에게만 수정하기 버튼 표시
- 리더 나가기 시도 시 위임 요청 알림
- API 응답에 `user_id`가 없어 임시로 `nickname`으로 본인 확인

## 💬 리뷰 포인트

## 📸 스크린샷 (선택)

## 🧠 기타 참고사항

<!-- 추가로 알아야 할 점 (예: 임시로 넣은 더미 데이터 있음) -->

## ✅ PR 체크리스트

- [ ] 커밋 컨벤션 준수 (예: `feat: 로그인 구현`)
- [ ] 불필요한 console.log 제거
- [ ] 로컬에서 실행 확인 완료
