### PR TITLE
fix: 로그인 시 디폴트 프로필 이미지 반영 (다른 팀과 통일 및 사이즈는 피그마 기준)

### DIFF
--- a/src/components/layout/header/Header.tsx
+++ b/src/components/layout/header/Header.tsx
@@ -21,7 +21,6 @@ export function Header({ isSideBarOpen, setIsSideBarOpen }: HeaderProps) {
   }
 
   // API 연결 시 임시 버튼
-
   const handleDevLogin = async () => {
     const token = await devLogin(
       import.meta.env.VITE_DEV_EMAIL!,

--- a/src/components/layout/header/User.tsx
+++ b/src/components/layout/header/User.tsx
@@ -1,10 +1,11 @@
 import { UserModal } from '@/components/layout'
 import { EXTERNAL_LINKS } from '@/constants'
 import { useIsDesktop, useUserData } from '@/hooks'
-import { BellIcon, ChevronDown, ChevronUp, UserRound } from 'lucide-react'
+import { BellIcon, ChevronDown, ChevronUp } from 'lucide-react'
 import { useState } from 'react'
 import { AnimatePresence } from 'framer-motion'
 import NotificationModal from '@/components/notification/NotificationModal'
+import defaultImg from '@/assets/images/defaultProfileImg.svg'
 
 export function User() {
   const [isUserModalOpen, setIsUserModalOpen] = useState(false)
@@ -94,16 +95,12 @@ export function User() {
         className="relative ml-4 flex cursor-pointer items-center gap-2"
         onClick={handleUserModal}
       >
-        <div className="flex h-8 w-8 items-center justify-center rounded-full">
-          {data?.profile_img_url ? (
-            <img
-              src={data.profile_img_url}
-              alt="profileIcon"
-              className="h-5 w-5 rounded-full"
-            />
-          ) : (
-            <UserRound className="h-5 w-5" />
-          )}
+        <div className="h-7 w-7 overflow-hidden rounded-full sm:h-8 sm:w-8">
+          <img
+            src={data?.profile_img_url || defaultImg}
+            alt="profileIcon"
+            className="h-full w-full object-cover"
+          />
         </div>
         <div className="text-primary-600 text-base">{data?.name}</div>
         {isUserModalOpen ? <ChevronUp /> : <ChevronDown />}

--- a/src/components/layout/header/User.tsx
+++ b/src/components/layout/header/User.tsx
@@ -103,7 +103,11 @@ export function User() {
           />
         </div>
         <div className="text-primary-600 text-base">{data?.name}</div>
-        {isUserModalOpen ? <ChevronUp /> : <ChevronDown />}
+        {isUserModalOpen ? (
+          <ChevronUp className="hidden md:block md:h-4 md:w-4" />
+        ) : (
+          <ChevronDown className="hidden md:block md:h-4 md:w-4" />
+        )}
         {isUserModalOpen && <UserModal />}
         {/* 추후 목업데이터로 먼저 구현예정 */}
       </div>


### PR DESCRIPTION
## ✨ PR 개요

로그인 시 디폴트 프로필 이미지 반영 (다른 팀과 통일 및 사이즈는 피그마 기준)

## 📌 관련 이슈

Closes #302

## 🧩 작업 내용 (주요 변경사항)

- 로그인 시 디폴트 프로필 이미지 반영 (다른 팀과 통일 및 사이즈는 피그마 기준)
- ChevronUp 아이콘 사이즈 수정

## 💬 리뷰 포인트

## 📸 스크린샷 (선택)

### 1팀
<img width="956" height="63" alt="스크린샷 2025-12-25 오후 9 48 44" src="https://github.com/user-attachments/assets/cf992ed8-2185-40c8-9585-782c7e9417c3" />

### 2팀
<img width="956" height="63" alt="스크린샷 2025-12-25 오후 9 48 58" src="https://github.com/user-attachments/assets/f958257b-efe4-48ac-8216-718f8278cc69" />

## 🧠 기타 참고사항

## ✅ PR 체크리스트

- [ ] 커밋 컨벤션 준수 (예: `feat: 로그인 구현`)
- [ ] 불필요한 console.log 제거
- [ ] 로컬에서 실행 확인 완료
