### PR TITLE
feat: 스터디 노트 마크다운 에디터 이미지 drag&drop 반영

### DIFF
--- a/src/components/markdown/EditorTextarea.tsx
+++ b/src/components/markdown/EditorTextarea.tsx
@@ -3,17 +3,33 @@ import { forwardRef } from 'react'
 interface EditorTextareaProps {
   value: string
   setValue: (value: string) => void
+  onImageUpload?: (file: File) => Promise<string>
 }
 
 export const EditorTextarea = forwardRef<
   HTMLTextAreaElement,
   EditorTextareaProps
->(({ value, setValue }, ref) => {
+>(({ value, setValue, onImageUpload }, ref) => {
+  const handleDrop = async (e: React.DragEvent) => {
+    e.preventDefault()
+    if (!onImageUpload) return
+
+    const files = Array.from(e.dataTransfer.files).filter((file) =>
+      file.type.startsWith('image/')
+    )
+
+    for (const file of files) {
+      const url = await onImageUpload(file)
+      setValue(value + `\n![${file.name}](${url})\n`)
+    }
+  }
   return (
     <textarea
       ref={ref}
       value={value}
       onChange={(e) => setValue(e.target.value)}
+      onDragOver={(e) => e.preventDefault()}
+      onDrop={handleDrop}
       placeholder="스터디 그룹에 대한 설명을 작성하세요. 마크다운 문법을 사용할 수 있습니다."
       className="remove-focus-outline min-h-[200px] w-full resize-none border-0 p-4"
     ></textarea>

--- a/src/components/markdown/MarkdownEditor.tsx
+++ b/src/components/markdown/MarkdownEditor.tsx
@@ -10,11 +10,13 @@ import { useMarkdownEditor } from '@/hooks'
 interface MarkdownEditorProps {
   value: string
   onChange: (v: string) => void
+  onImageUpload?: (file: File) => Promise<string>
 }
 
 export function MarkdownEditor({
   value,
   onChange: setValue,
+  onImageUpload,
 }: MarkdownEditorProps) {
   const { textareaRef, insertMarkdown } = useMarkdownEditor({ value, setValue })
   const [mode, setMode] = useState<'write' | 'preview'>('write')
@@ -27,7 +29,12 @@ export function MarkdownEditor({
         insertMarkdown={insertMarkdown}
       />
       {mode === 'write' ? (
-        <EditorTextarea ref={textareaRef} value={value} setValue={setValue} />
+        <EditorTextarea
+          ref={textareaRef}
+          value={value}
+          setValue={setValue}
+          onImageUpload={onImageUpload}
+        />
       ) : (
         <Preview value={value} />
       )}

--- a/src/pages/CreateStudyNotePage.tsx
+++ b/src/pages/CreateStudyNotePage.tsx
@@ -1,3 +1,4 @@
+import { getPresignedUrl, uploadToS3 } from '@/api'
 import { Button, Input } from '@/components/common'
 import { MarkdownEditor } from '@/components/markdown'
 import { FileUploader } from '@/components/studygroup-detail'
@@ -77,6 +78,27 @@ export function CreateStudyNotePage() {
     }
   }
 
+  const handleImageUpload = async (file: File): Promise<string> => {
+    const fileExt = file.name.split('.').pop() ?? ''
+
+    try {
+      const { upload_url, file_url, headers } = await getPresignedUrl({
+        type: 'NOTE_IMAGE',
+        content_type: file.type,
+        file_name: file.name,
+        file_ext: fileExt,
+      })
+
+      await uploadToS3(upload_url, file, headers)
+
+      return file_url
+    } catch (error) {
+      console.error('이미지 업로드', error)
+      showToast.error('업로드 실패', '이미지 업로드에 실패했습니다.')
+      throw error
+    }
+  }
+
   const handleCancel = () => {
     navigate(-1)
   }
@@ -107,7 +129,11 @@ export function CreateStudyNotePage() {
           <label className="text-custom-gray-700 text-sm font-medium">
             내용 <span className="text-red-500">*</span>
           </label>
-          <MarkdownEditor value={content} onChange={setContent} />
+          <MarkdownEditor
+            value={content}
+            onChange={setContent}
+            onImageUpload={handleImageUpload}
+          />
           <span className="text-custom-gray-500 text-xs">
             마크다운 문법을 사용할 수 있습니다. 이미지는 드래그 앤 드롭으로
             첨부할 수 있습니다.

--- a/src/pages/CreateStudyNotePage.tsx
+++ b/src/pages/CreateStudyNotePage.tsx
@@ -108,6 +108,10 @@ export function CreateStudyNotePage() {
             내용 <span className="text-red-500">*</span>
           </label>
           <MarkdownEditor value={content} onChange={setContent} />
+          <span className="text-custom-gray-500 text-xs">
+            마크다운 문법을 사용할 수 있습니다. 이미지는 드래그 앤 드롭으로
+            첨부할 수 있습니다.
+          </span>
         </div>
 
         <div>

--- a/src/pages/DetailStudyNotePage.tsx
+++ b/src/pages/DetailStudyNotePage.tsx
@@ -85,7 +85,7 @@ export function DetailStudyNotePage() {
           </div>
           {isSummaryOpen && (
             <div className="text-custom-gray-900 bg-amber-50 p-4">
-              <p>{data.ai_summary}</p>
+              <Preview value={data.ai_summary ?? ''} />
             </div>
           )}
         </section>

--- a/src/pages/EditStudyNotePage.tsx
+++ b/src/pages/EditStudyNotePage.tsx
@@ -1,3 +1,4 @@
+import { getPresignedUrl, uploadToS3 } from '@/api'
 import { Button, Input } from '@/components/common'
 import { MarkdownEditor } from '@/components/markdown'
 import { FileUploader } from '@/components/studygroup-detail'
@@ -93,6 +94,27 @@ export function EditStudyNotePage() {
     }
   }
 
+  const handleImageUpload = async (file: File): Promise<string> => {
+    const fileExt = file.name.split('.').pop() ?? ''
+
+    try {
+      const { upload_url, file_url, headers } = await getPresignedUrl({
+        type: 'NOTE_IMAGE',
+        content_type: file.type,
+        file_name: file.name,
+        file_ext: fileExt,
+      })
+
+      await uploadToS3(upload_url, file, headers)
+
+      return file_url
+    } catch (error) {
+      console.error('이미지 업로드', error)
+      showToast.error('업로드 실패', '이미지 업로드에 실패했습니다.')
+      throw error
+    }
+  }
+
   const handleCancel = () => {
     navigate(-1)
   }
@@ -123,7 +145,11 @@ export function EditStudyNotePage() {
           <label className="text-custom-gray-700 text-sm font-medium">
             내용 <span className="text-red-500">*</span>
           </label>
-          <MarkdownEditor value={content} onChange={setContent} />
+          <MarkdownEditor
+            value={content}
+            onChange={setContent}
+            onImageUpload={handleImageUpload}
+          />
           <span className="text-custom-gray-500 text-xs">
             마크다운 문법을 사용할 수 있습니다. 이미지는 드래그 앤 드롭으로
             첨부할 수 있습니다.

--- a/src/pages/EditStudyNotePage.tsx
+++ b/src/pages/EditStudyNotePage.tsx
@@ -124,6 +124,10 @@ export function EditStudyNotePage() {
             내용 <span className="text-red-500">*</span>
           </label>
           <MarkdownEditor value={content} onChange={setContent} />
+          <span className="text-custom-gray-500 text-xs">
+            마크다운 문법을 사용할 수 있습니다. 이미지는 드래그 앤 드롭으로
+            첨부할 수 있습니다.
+          </span>
         </div>
 
         <div>


### PR DESCRIPTION
## ✨ PR 개요

스터디 노트 마크다운 에디터 이미지 drag&drop 반영

## 📌 관련 이슈

Closes #304

## 🧩 작업 내용 (주요 변경사항)

- 스터디 노트 마크다운 에디터 이미지 drag&drop 반영

## 💬 리뷰 포인트

## 📸 스크린샷 (선택)

## 🧠 기타 참고사항

## ✅ PR 체크리스트

- [ ] 커밋 컨벤션 준수 (예: `feat: 로그인 구현`)
- [ ] 불필요한 console.log 제거
- [ ] 로컬에서 실행 확인 완료
